### PR TITLE
Update dependencies and adopt Simple-PHP-Code-Parser 0.22 model APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+- Updated dependencies: `voku/simple-php-code-parser` to `^0.22.2`, `nikic/php-parser` to `^5.8`, `helgesverre/toon` to `^3.2`, `phpstan/phpstan` to `^2.2.8`, `phpunit/phpunit` to `^12.5`, and `infection/infection` to `^0.34.2`. `symfony/console` stays on `^7.4` because Symfony 8 requires PHP 8.4 and this package still supports PHP 8.3.
+- Resolved imported PHPDoc types before comparing them with native types, so `use Vendor\Payload as Message;` with `@param Message $message` on a `Payload $message` parameter is no longer reported as a mismatch.
+- Extended `php.misleading-phpdoc-types` to interface, trait, and enum members and to `@var` annotations on typed properties, including every property of a grouped `public string $a, $b;` declaration.
+- Reported PHPDoc findings at the line of the annotated parameter instead of the enclosing declaration line, so multi-line signatures point at the right place.
+- Treated `mixed` unions as equivalent to `mixed`, so `@param mixed|null $value` on a `mixed` parameter is reported as redundant rather than as a disagreement.
+- Bumped the `php.structure` fact cache schema version, so existing `.slop-scan.cache.json` files are recomputed instead of replayed against the new PHPDoc fact shape.
+
 ## 0.1.4 - 2026-05-18
 
 - Refine excessive suppression counting, so that it's not so noisy. (ignored errors via identifier + comment are ok)

--- a/composer.json
+++ b/composer.json
@@ -4,15 +4,15 @@
     "type": "project",
     "require": {
         "php": "^8.3",
-        "nikic/php-parser": "^5.7",
+        "nikic/php-parser": "^5.8",
         "symfony/console": "^7.4",
-        "voku/simple-php-code-parser": "^0.21.0",
-        "helgesverre/toon": "^3.1"
+        "voku/simple-php-code-parser": "^0.22.2",
+        "helgesverre/toon": "^3.2"
     },
     "require-dev": {
-        "infection/infection": "^0.32.7",
-        "phpstan/phpstan": "^2.1.54",
-        "phpunit/phpunit": "^11.5"
+        "infection/infection": "^0.34.2",
+        "phpstan/phpstan": "^2.2.8",
+        "phpunit/phpunit": "^12.5"
     },
     "license": "MIT",
     "authors": [

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -32,7 +32,7 @@ It also scans Markdown docs:
 | `php.debug-output` | Calls like `var_dump()`, `print_r()`, `dd()`, or `ray()` left in source | Debug leftovers usually should not ship in production code. |
 | `php.mock-heavy-tests-without-assertions` | Tests that mostly build mocks but do not assert behavior | These tests look busy but often do not protect behavior. |
 | `php.magic-numbers` | Inline numeric literals and numeric strings inside function or method bodies, except configured ignored values like `0` and `1` | Unnamed numbers hide intent and are harder to review or change safely. |
-| `php.misleading-phpdoc-types` | PHPDoc param/return types that either disagree with or merely duplicate native types | Misleading docs undermine trust, while redundant docs add noise without extra type value. |
+| `php.misleading-phpdoc-types` | PHPDoc `@param`, `@return`, and `@var` types on functions, methods, and properties that either disagree with or merely duplicate native types | Misleading docs undermine trust, while redundant docs add noise without extra type value. Imported aliases are resolved before comparison, so `use Vendor\Payload as Message;` does not read as a mismatch. |
 | `php.placeholder-comments` | Comments such as TODO, FIXME, HACK, placeholder, temporary | These markers often reveal unfinished or intentionally deferred work. |
 | `php.pass-through-wrappers` | Functions that mostly forward input to another function | Thin wrappers can indicate unnecessary indirection and generated-looking structure. |
 | `php.directory-fanout-hotspot` | Directories with unusually high PHP file counts | Large clusters of files can indicate sprawl and review-unfriendly structure. |

--- a/src/Fact/PhpFacts.php
+++ b/src/Fact/PhpFacts.php
@@ -15,6 +15,13 @@ use PhpParser\Node\Stmt;
 use PhpParser\Parser;
 use PhpParser\ParserFactory;
 use PhpParser\PrettyPrinter\Standard;
+use voku\SimplePhpParser\Model\PHPClass;
+use voku\SimplePhpParser\Model\PHPEnum;
+use voku\SimplePhpParser\Model\PHPFunction;
+use voku\SimplePhpParser\Model\PHPInterface;
+use voku\SimplePhpParser\Model\PHPProperty;
+use voku\SimplePhpParser\Model\PHPTrait;
+use voku\SimplePhpParser\Parsers\Helper\ParserContainer;
 use voku\SimplePhpParser\Parsers\PhpCodeParser;
 
 final class PhpFacts
@@ -95,8 +102,8 @@ final class PhpFacts
      *     kind:string,
      *     subject:string,
      *     line:int,
-     *     params:list<array{name:string,nativeType:?string,phpDocType:?string,phpDocRaw:?string,phpDocExtendedType:?string}>,
-     *     return:null|array{nativeType:?string,phpDocType:?string,phpDocRaw:?string,phpDocExtendedType:?string}
+     *     endLine:?int,
+     *     annotations:list<array{annotation:string,tag:string,variable:?string,line:int,nativeType:?string,phpDocType:?string,phpDocResolvedType:?string,phpDocRaw:?string,phpDocExtendedType:?string}>
      * }>
      */
     public static function phpDocTypeSummaries(string $absolutePath): array
@@ -112,18 +119,23 @@ final class PhpFacts
         }
 
         $entries = [];
-        foreach ($container->getFunctionsInfo() as $functionName => $info) {
-            $entry = self::phpDocTypeSummaryEntry('function', (string) $functionName, null, $info);
+        foreach ($container->getFunctions() as $functionName => $function) {
+            $entry = self::phpDocFunctionEntry('function', (string) $functionName, null, $function);
             if ($entry !== null) {
                 $entries[] = $entry;
             }
         }
 
-        $classes = $container->getClasses();
-        ksort($classes, SORT_STRING);
-        foreach ($classes as $className => $class) {
-            foreach ($class->getMethodsInfo() as $methodName => $info) {
-                $entry = self::phpDocTypeSummaryEntry('method', (string) $methodName, (string) $className, $info);
+        foreach (self::classLikeModels($container) as $className => $classLike) {
+            foreach ($classLike->methods as $method) {
+                $entry = self::phpDocFunctionEntry('method', $method->name, $className, $method);
+                if ($entry !== null) {
+                    $entries[] = $entry;
+                }
+            }
+
+            foreach ($classLike->properties as $property) {
+                $entry = self::phpDocPropertyEntry($className, $property);
                 if ($entry !== null) {
                     $entries[] = $entry;
                 }
@@ -531,55 +543,146 @@ final class PhpFacts
     }
 
     /**
-     * @param array<string,mixed> $info
+     * Class-likes that can carry documented members, keyed by their fully qualified name.
+     *
+     * @return array<string,PHPClass|PHPEnum|PHPInterface|PHPTrait>
+     */
+    private static function classLikeModels(ParserContainer $container): array
+    {
+        $classLikes = array_merge(
+            $container->getClasses(),
+            $container->getInterfaces(),
+            $container->getTraits(),
+            $container->getEnums()
+        );
+        ksort($classLikes, SORT_STRING);
+
+        return $classLikes;
+    }
+
+    /**
      * @return null|array{
      *     kind:string,
      *     subject:string,
      *     line:int,
-     *     params:list<array{name:string,nativeType:?string,phpDocType:?string,phpDocRaw:?string,phpDocExtendedType:?string}>,
-     *     return:null|array{nativeType:?string,phpDocType:?string,phpDocRaw:?string,phpDocExtendedType:?string}
+     *     endLine:?int,
+     *     annotations:list<array{annotation:string,tag:string,variable:?string,line:int,nativeType:?string,phpDocType:?string,phpDocResolvedType:?string,phpDocRaw:?string,phpDocExtendedType:?string}>
      * }
      */
-    private static function phpDocTypeSummaryEntry(string $kind, string $memberName, ?string $className, array $info): ?array
+    private static function phpDocFunctionEntry(string $kind, string $memberName, ?string $className, PHPFunction $function): ?array
     {
-        $params = [];
-        foreach (($info['paramsTypes'] ?? []) as $paramName => $types) {
-            $raw = $info['paramsPhpDocRaw'][$paramName] ?? null;
-            if (!is_string($raw) || trim($raw) === '') {
-                continue;
-            }
+        $declarationLine = $function->line ?? 1;
 
-            $params[] = [
-                'name' => (string) $paramName,
-                'nativeType' => is_string($types['type'] ?? null) ? $types['type'] : null,
-                'phpDocType' => is_string($types['typeFromPhpDoc'] ?? null) ? $types['typeFromPhpDoc'] : null,
-                'phpDocRaw' => $raw,
-                'phpDocExtendedType' => is_string($types['typeFromPhpDocExtended'] ?? null) ? $types['typeFromPhpDocExtended'] : null,
-            ];
+        $annotations = [];
+        foreach ($function->parameters as $parameter) {
+            $annotation = self::phpDocAnnotation(
+                '@param',
+                $parameter->name,
+                $parameter->line ?? $declarationLine,
+                $parameter->type,
+                $parameter->typeFromPhpDoc,
+                $parameter->typeFromPhpDocResolved,
+                $parameter->phpDocRaw,
+                $parameter->typeFromPhpDocExtended
+            );
+            if ($annotation !== null) {
+                $annotations[] = $annotation;
+            }
         }
 
-        $returnRaw = $info['returnPhpDocRaw'] ?? null;
-        $return = is_string($returnRaw) && trim($returnRaw) !== ''
-            ? [
-                'nativeType' => is_string($info['returnTypes']['type'] ?? null) ? $info['returnTypes']['type'] : null,
-                'phpDocType' => is_string($info['returnTypes']['typeFromPhpDoc'] ?? null) ? $info['returnTypes']['typeFromPhpDoc'] : null,
-                'phpDocRaw' => $returnRaw,
-                'phpDocExtendedType' => is_string($info['returnTypes']['typeFromPhpDocExtended'] ?? null) ? $info['returnTypes']['typeFromPhpDocExtended'] : null,
-            ]
-            : null;
+        $return = self::phpDocAnnotation(
+            '@return',
+            null,
+            $declarationLine,
+            $function->returnType,
+            $function->returnTypeFromPhpDoc,
+            $function->returnTypeFromPhpDocResolved,
+            $function->returnPhpDocRaw,
+            $function->returnTypeFromPhpDocExtended
+        );
+        if ($return !== null) {
+            $annotations[] = $return;
+        }
 
-        if ($params === [] && $return === null) {
+        if ($annotations === []) {
             return null;
         }
 
-        $subject = $className !== null ? $className . '::' . $memberName : $memberName;
-
         return [
             'kind' => $kind,
-            'subject' => $subject,
-            'line' => is_int($info['line'] ?? null) ? $info['line'] : 1,
-            'params' => $params,
-            'return' => $return,
+            'subject' => $className !== null ? $className . '::' . $memberName : $memberName,
+            'line' => $declarationLine,
+            'endLine' => $function->endLine,
+            'annotations' => $annotations,
+        ];
+    }
+
+    /**
+     * @return null|array{
+     *     kind:string,
+     *     subject:string,
+     *     line:int,
+     *     endLine:?int,
+     *     annotations:list<array{annotation:string,tag:string,variable:?string,line:int,nativeType:?string,phpDocType:?string,phpDocResolvedType:?string,phpDocRaw:?string,phpDocExtendedType:?string}>
+     * }
+     */
+    private static function phpDocPropertyEntry(string $className, PHPProperty $property): ?array
+    {
+        $declarationLine = $property->line ?? 1;
+
+        $annotation = self::phpDocAnnotation(
+            '@var',
+            $property->name,
+            $declarationLine,
+            $property->type,
+            $property->typeFromPhpDoc,
+            $property->typeFromPhpDocResolved,
+            $property->phpDocRaw,
+            $property->typeFromPhpDocExtended
+        );
+        if ($annotation === null) {
+            return null;
+        }
+
+        return [
+            'kind' => 'property',
+            'subject' => $className . '::$' . $property->name,
+            'line' => $declarationLine,
+            'endLine' => $property->endLine,
+            'annotations' => [$annotation],
+        ];
+    }
+
+    /**
+     * @param string  $tag      PHPDoc tag this annotation came from, such as `@param`.
+     * @param ?string $variable Variable the raw PHPDoc line repeats after the type, when the tag carries one.
+     *
+     * @return null|array{annotation:string,tag:string,variable:?string,line:int,nativeType:?string,phpDocType:?string,phpDocResolvedType:?string,phpDocRaw:?string,phpDocExtendedType:?string}
+     */
+    private static function phpDocAnnotation(
+        string $tag,
+        ?string $variable,
+        int $line,
+        ?string $nativeType,
+        ?string $phpDocType,
+        ?string $phpDocResolvedType,
+        ?string $phpDocRaw,
+        ?string $phpDocExtendedType
+    ): ?array {
+        if ($phpDocRaw === null || trim($phpDocRaw) === '') {
+            return null;
+        }
+
+        return [
+            'annotation' => $variable !== null ? $tag . ' $' . $variable : $tag,
+            'tag' => $tag,
+            'variable' => $variable,
+            'line' => $line,
+            'nativeType' => $nativeType,
+            'phpDocType' => $phpDocType,
+            'phpDocResolvedType' => $phpDocResolvedType,
+            'phpDocRaw' => $phpDocRaw,
+            'phpDocExtendedType' => $phpDocExtendedType,
         ];
     }
 
@@ -810,7 +913,6 @@ final class PhpFacts
     }
 
     /**
-     * @param mixed $value
      * @param callable(Node, ?Node): bool $visitor
      */
     private static function walkNodes(mixed $value, ?Node $parent, callable $visitor): void

--- a/src/Rule/MisleadingPhpDocTypesRule.php
+++ b/src/Rule/MisleadingPhpDocTypesRule.php
@@ -20,12 +20,19 @@ final class MisleadingPhpDocTypesRule extends BaseRule
         $findings = [];
 
         foreach ($context->runtime->store->getFileFact($context->file->path, 'file.phpDocTypeSummaries') ?? [] as $entry) {
-            foreach ($entry['params'] as $param) {
-                $issue = self::issueForTypes($param['nativeType'], $param['phpDocType'], $param['phpDocRaw'], $param['phpDocExtendedType']);
+            foreach ($entry['annotations'] as $annotation) {
+                $issue = self::issueForTypes(
+                    $annotation['nativeType'],
+                    $annotation['phpDocResolvedType'] ?? $annotation['phpDocType'],
+                    $annotation['phpDocRaw'],
+                    $annotation['phpDocExtendedType']
+                );
                 if ($issue === null) {
                     continue;
                 }
-                if ($issue['kind'] === 'redundant' && self::hasDescriptionText($param['phpDocRaw'], $param['name'])) {
+                // `@param` repeats the variable between type and description, `@return` and `@var` do not.
+                $repeatedVariable = $annotation['tag'] === '@param' ? $annotation['variable'] : null;
+                if ($issue['kind'] === 'redundant' && self::hasDescriptionText($annotation['phpDocRaw'], $repeatedVariable)) {
                     continue;
                 }
 
@@ -39,49 +46,16 @@ final class MisleadingPhpDocTypesRule extends BaseRule
                         : 'Found misleading PHPDoc type annotation that disagrees with the native signature',
                     [
                         'subject=' . $entry['subject'],
-                        'annotation=@param $' . $param['name'],
-                        'native=' . $param['nativeType'],
-                        'phpdoc=' . $param['phpDocRaw'],
+                        'annotation=' . $annotation['annotation'],
+                        'native=' . $annotation['nativeType'],
+                        'phpdoc=' . $annotation['phpDocRaw'],
                         'reason=' . $issue['reason'],
                     ],
                     $issue['kind'] === 'redundant' ? 0.75 : 1.5,
-                    [['path' => $context->file->path, 'line' => $entry['line'], 'column' => 1]],
+                    [['path' => $context->file->path, 'line' => $annotation['line'], 'column' => 1]],
                     $context->file->path
                 );
             }
-
-            $return = $entry['return'] ?? null;
-            if ($return === null) {
-                continue;
-            }
-
-            $issue = self::issueForTypes($return['nativeType'], $return['phpDocType'], $return['phpDocRaw'], $return['phpDocExtendedType']);
-            if ($issue === null) {
-                continue;
-            }
-            if ($issue['kind'] === 'redundant' && self::hasDescriptionText($return['phpDocRaw'], null)) {
-                continue;
-            }
-
-            $findings[] = new Finding(
-                $this->id(),
-                $this->family(),
-                $this->severity(),
-                'file',
-                $issue['kind'] === 'redundant'
-                    ? 'Found redundant PHPDoc type annotation that repeats the native signature'
-                    : 'Found misleading PHPDoc type annotation that disagrees with the native signature',
-                [
-                    'subject=' . $entry['subject'],
-                    'annotation=@return',
-                    'native=' . $return['nativeType'],
-                    'phpdoc=' . $return['phpDocRaw'],
-                    'reason=' . $issue['reason'],
-                ],
-                $issue['kind'] === 'redundant' ? 0.75 : 1.5,
-                [['path' => $context->file->path, 'line' => $entry['line'], 'column' => 1]],
-                $context->file->path
-            );
         }
 
         return $findings;
@@ -128,6 +102,12 @@ final class MisleadingPhpDocTypesRule extends BaseRule
             static fn(string $part): string => ltrim(trim($part), '\\'),
             explode('|', str_replace(' ', '', $type))
         ));
+
+        // `mixed` already covers every other member of a union, including `null`.
+        if (in_array('mixed', $parts, true)) {
+            return 'mixed';
+        }
+
         sort($parts, SORT_STRING);
 
         return implode('|', array_values(array_unique($parts)));

--- a/src/Support/ScanCache.php
+++ b/src/Support/ScanCache.php
@@ -8,7 +8,7 @@ final class ScanCache
 {
     private const FORMAT_VERSION = 1;
     private const PROVIDER_SCHEMA_VERSIONS = [
-        'php.structure' => 1,
+        'php.structure' => 2,
     ];
 
     /** @var array<string,array<string,array{fingerprint:string,facts:array<string,mixed>}>> */

--- a/tests/PhpCliTest.php
+++ b/tests/PhpCliTest.php
@@ -674,6 +674,71 @@ PHP);
         $this->remove($fixture);
     }
 
+    public function testMisleadingPhpDocTypeRuleKeepsDescribedPropertyAnnotations(): void
+    {
+        $fixture = $this->makeFixture();
+        mkdir($fixture . '/src', 0777, true);
+        file_put_contents($fixture . '/src/DescribedProperty.php', <<<'PHP'
+<?php
+
+final class DescribedProperty
+{
+    /** @var string Visible label from the external system */
+    public string $label = '';
+
+    /** @var string */
+    public string $key = '';
+}
+PHP);
+
+        $result = (new Analyzer())->analyze($fixture, Config::defaults(), DefaultRegistry::create());
+
+        self::assertSame(
+            [
+                'subject=DescribedProperty::$key',
+                'annotation=@var $key',
+                'native=string',
+                'phpdoc=string',
+                'reason=phpdoc-repeats-native-type',
+            ],
+            $this->findEvidenceForRuleAndLine($result->findings, 'php.misleading-phpdoc-types', 9)
+        );
+        self::assertSame(1, $this->countForRule($result->findings, 'php.misleading-phpdoc-types'));
+
+        $this->remove($fixture);
+    }
+
+    public function testMisleadingPhpDocTypeRuleTreatsMixedUnionsAsTheSameNativeType(): void
+    {
+        $fixture = $this->makeFixture();
+        mkdir($fixture . '/src', 0777, true);
+        file_put_contents($fixture . '/src/MixedDocs.php', <<<'PHP'
+<?php
+
+/**
+ * @param mixed|null $value
+ */
+function accepts_anything(mixed $value): void
+{
+}
+PHP);
+
+        $result = (new Analyzer())->analyze($fixture, Config::defaults(), DefaultRegistry::create());
+
+        self::assertSame(
+            [
+                'subject=accepts_anything',
+                'annotation=@param $value',
+                'native=mixed',
+                'phpdoc=mixed|null $value',
+                'reason=phpdoc-repeats-native-type',
+            ],
+            $this->findEvidenceForRuleAndLine($result->findings, 'php.misleading-phpdoc-types', 6)
+        );
+
+        $this->remove($fixture);
+    }
+
     public function testMisleadingPhpDocTypeRuleDoesNotFlagHelpfulDescriptionsOnMatchingTypes(): void
     {
         $fixture = $this->makeFixture();
@@ -716,6 +781,7 @@ PHP);
             'mock heavy test without assertions' => ['mock-heavy-test-without-assertions.fixture', 'tests/OnlyMocksTest.php', 'php.mock-heavy-tests-without-assertions'],
             'magic numbers' => ['magic-number.fixture', 'src/MagicNumber.php', 'php.magic-numbers'],
             'misleading phpdoc types' => ['misleading-phpdoc-types.fixture', 'src/MisleadingPhpDoc.php', 'php.misleading-phpdoc-types'],
+            'misleading phpdoc property' => ['misleading-phpdoc-property.fixture', 'src/MisleadingPhpDocProperty.php', 'php.misleading-phpdoc-types'],
             'placeholder comments' => ['placeholder-comments.fixture', 'src/PlaceholderComments.php', 'php.placeholder-comments'],
             'pass through wrapper' => ['pass-through-wrapper.fixture', 'src/PassThroughWrapper.php', 'php.pass-through-wrappers'],
             'return constant stub' => ['return-constant-stub.fixture', 'src/ReturnConstantStub.php', 'php.return-constant-stub'],
@@ -751,6 +817,7 @@ PHP);
             'error wrapping with previous' => ['error-wrapping-with-previous.fixture', 'src/ErrorWrappingWithPrevious.php'],
             'test with mocks and assertions' => ['test-with-mocks-and-real-assertions.fixture', 'tests/MockAssertionsTest.php'],
             'helpful phpdoc types' => ['helpful-phpdoc-types.fixture', 'src/HelpfulPhpDoc.php'],
+            'aliased phpdoc types' => ['aliased-phpdoc-types.fixture', 'src/AliasedPhpDoc.php'],
             'installation markdown' => ['installation-guide-markdown.fixture', 'docs/installation.md'],
             'contributing markdown' => ['contributing-markdown.fixture', 'docs/contributing.md'],
             'release checklist markdown' => ['release-checklist-markdown.fixture', 'docs/release-checklist.md'],
@@ -2852,10 +2919,90 @@ PHP);
         $summaries = PhpFacts::phpDocTypeSummaries($file);
 
         self::assertSame(['format_name', 'Formatter::names'], array_column($summaries, 'subject'));
-        self::assertSame('string', $summaries[0]['params'][0]['nativeType']);
-        self::assertSame('string|null', $summaries[0]['return']['phpDocType']);
-        self::assertSame('int', $summaries[1]['params'][0]['nativeType']);
-        self::assertSame('array<int, string>', $summaries[1]['return']['phpDocExtendedType']);
+        self::assertSame(['@param $name', '@return'], array_column($summaries[0]['annotations'], 'annotation'));
+        self::assertSame('string', $summaries[0]['annotations'][0]['nativeType']);
+        self::assertSame('string|null', $summaries[0]['annotations'][1]['phpDocType']);
+        self::assertSame('int', $summaries[1]['annotations'][0]['nativeType']);
+        self::assertSame('array<int, string>', $summaries[1]['annotations'][1]['phpDocExtendedType']);
+        self::assertSame(7, $summaries[0]['line']);
+        self::assertSame(9, $summaries[0]['endLine']);
+    }
+
+    public function testPhpFactsCollectPhpDocTypeSummariesFromInterfacesTraitsAndProperties(): void
+    {
+        $file = $this->fixtureDir . '/src/PhpDocMembers.php';
+        file_put_contents($file, <<<'PHP'
+<?php
+
+interface Renderer
+{
+    /** @return string */
+    public function render(): string;
+}
+
+trait Loud
+{
+    /** @var string */
+    public string $volume = 'high';
+}
+
+final class Widget
+{
+    /** @var int */
+    public string $label = '';
+}
+PHP);
+
+        $summaries = PhpFacts::phpDocTypeSummaries($file);
+
+        self::assertSame(
+            ['Renderer::render', 'Loud::$volume', 'Widget::$label'],
+            array_column($summaries, 'subject')
+        );
+        self::assertSame(['method', 'property', 'property'], array_column($summaries, 'kind'));
+        self::assertSame('@var $volume', $summaries[1]['annotations'][0]['annotation']);
+        self::assertSame('@var', $summaries[1]['annotations'][0]['tag']);
+        self::assertSame('volume', $summaries[1]['annotations'][0]['variable']);
+        self::assertSame('@return', $summaries[0]['annotations'][0]['tag']);
+        self::assertNull($summaries[0]['annotations'][0]['variable']);
+        self::assertSame('int', $summaries[2]['annotations'][0]['phpDocType']);
+        self::assertSame('string', $summaries[2]['annotations'][0]['nativeType']);
+    }
+
+    public function testPhpFactsResolveImportedPhpDocTypesAndParameterLines(): void
+    {
+        $file = $this->fixtureDir . '/src/PhpDocImports.php';
+        file_put_contents($file, <<<'PHP'
+<?php
+
+namespace Demo;
+
+use Demo\Support\Payload as Message;
+use Demo\Support\Payload;
+
+final class Service
+{
+    /**
+     * @param Message $message
+     * @param int $count
+     */
+    public function handle(
+        Payload $message,
+        int $count
+    ): void {
+    }
+}
+PHP);
+
+        $summaries = PhpFacts::phpDocTypeSummaries($file);
+
+        self::assertSame(['Demo\Service::handle'], array_column($summaries, 'subject'));
+        self::assertSame('\Message', $summaries[0]['annotations'][0]['phpDocType']);
+        self::assertSame('\Demo\Support\Payload', $summaries[0]['annotations'][0]['phpDocResolvedType']);
+        self::assertSame('\Demo\Support\Payload', $summaries[0]['annotations'][0]['nativeType']);
+        self::assertSame(15, $summaries[0]['annotations'][0]['line']);
+        self::assertSame(16, $summaries[0]['annotations'][1]['line']);
+        self::assertSame(14, $summaries[0]['line']);
     }
 
     public function testParserSummaryHandlesUnavailableInjectedAndErrorStates(): void

--- a/tests/fixtures/clean/aliased-phpdoc-types.fixture
+++ b/tests/fixtures/clean/aliased-phpdoc-types.fixture
@@ -1,0 +1,19 @@
+<?php
+
+namespace Demo;
+
+use Demo\Support\Payload as Message;
+use Demo\Support\Payload;
+
+final class AliasedPhpDoc
+{
+    /**
+     * @param Message $message Payload received from the upstream queue
+     *
+     * @return Message Payload forwarded to the downstream queue
+     */
+    public function forward(Payload $message): Payload
+    {
+        return $message;
+    }
+}

--- a/tests/fixtures/slop/misleading-phpdoc-property.fixture
+++ b/tests/fixtures/slop/misleading-phpdoc-property.fixture
@@ -1,0 +1,9 @@
+<?php
+
+final class MisleadingPhpDocProperty
+{
+    /**
+     * @var int
+     */
+    public string $label = '';
+}


### PR DESCRIPTION
Raise voku/simple-php-code-parser to ^0.22.2 and refresh the remaining
constraints (nikic/php-parser ^5.8, helgesverre/toon ^3.2, phpstan ^2.2.8,
phpunit ^12.5, infection ^0.34.2). symfony/console stays on ^7.4 because
Symfony 8 requires PHP 8.4 while this package still supports PHP 8.3.

Rework file.phpDocTypeSummaries to read the parser's model objects instead
of the flattened *Info arrays, which makes the 0.22 additions available:

- import-aware typeFromPhpDocResolved / returnTypeFromPhpDocResolved, so an
  aliased `use Vendor\Payload as Message;` no longer reads as a type mismatch
- per-parameter source lines, so findings on multi-line signatures point at
  the annotated parameter rather than the declaration line
- interface, trait and enum members plus @var annotations on typed
  properties, including every property of a grouped declaration

Also treat `mixed` unions as equivalent to `mixed`, which the repository
self-scan surfaced as a misclassified redundant annotation, and drop the
redundant annotation it found in PhpFacts::walkNodes. The php.structure fact
cache schema version is bumped so existing caches are recomputed against the
new fact shape.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018jjM3YjguWsnS54jRNNnN7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved misleading PHPDoc detection for functions, methods, properties, interfaces, traits, and enums.
  * Resolved imported PHPDoc type aliases before comparison.
  * Improved diagnostic line reporting and handling of `mixed` unions.

* **Documentation**
  * Clarified the misleading PHPDoc types rule coverage and alias resolution.

* **Chores**
  * Updated runtime and development tooling dependencies.
  * Refreshed analysis caches to reflect the latest structural data format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->