### PR TITLE
Add delta and stats agent skills, and cut 0.1.5

### DIFF
--- a/.ai/skills/compare-slop-scan-delta.yaml
+++ b/.ai/skills/compare-slop-scan-delta.yaml
@@ -1,0 +1,50 @@
+name: compare-slop-scan-delta
+purpose: Compare two slop-scan inputs and report which findings a change added or resolved.
+triggers:
+  - compare slop-scan results before and after a change
+  - which findings did this branch add
+  - gate a change on new slop findings
+requiredEnvironment:
+  workingDirectory: repository root
+  runtime:
+    - PHP 8.3+
+  tools:
+    - php
+  prerequisites:
+    - Both sides must be comparable inputs, either two checkouts or two JSON reports produced by the scan command.
+inputs:
+  required:
+    - basePath: Relative path to the base checkout when comparing trees. Default "../main"
+    - headPath: Relative path to the head checkout when comparing trees. Default "."
+  optional:
+    - baseReport: Existing base JSON report file, used instead of basePath
+    - headReport: Existing head JSON report file, used instead of headPath
+    - baseConfigFile: Relative config path for the base tree when its config lives outside the scan root
+    - headConfigFile: Relative config path for the head tree when its config lives outside the scan root
+    - failOn: Comma-separated delta statuses that should fail the command, such as "added"
+commands:
+  - description: Preferred machine-readable comparison of two saved reports
+    template: php bin/slop-scan.php delta --base-report <baseReport> --head-report <headReport> --json
+  - description: Comparison of two checkouts when no reports exist yet
+    template: php bin/slop-scan.php delta --base <basePath> --head <headPath> --json
+    defaults:
+      basePath: ../main
+      headPath: .
+  - description: Produce the two reports a report comparison needs
+    template: php bin/slop-scan.php scan <scanPath> --config-file <configFile> --json
+    defaults:
+      scanPath: .
+      configFile: slop-scan.config.json
+  - description: Fail the command when a change introduces findings
+    template: php bin/slop-scan.php delta --base-report <baseReport> --head-report <headReport> --fail-on added
+expectedOutputs:
+  - JSON with `summary.added` and `summary.resolved` counts, plus a `changes` list whose entries carry `status`, `fingerprint`, and the full `finding`.
+  - Exit code 0 without --fail-on, even when the comparison reports added findings.
+  - Exit code 1 when --fail-on names a status that the comparison reports.
+failureHandling:
+  - Path options and report options are not interchangeable. --base and --head expect directories, while --base-report and --head-report expect JSON report files; passing a report file to --base fails with a directory error.
+  - If both sides produce identical fingerprints for a moved finding, confirm the line numbers, because fingerprints combine ruleId, message, path, and line.
+  - If a comparison reports unexpected churn, regenerate both reports with the same config file so both sides use identical rule settings.
+  - If either report file is missing or not valid JSON, regenerate it with the scan command before comparing.
+validationFollowUp:
+  - When comparing a work in progress against its base, regenerate the head report after each meaningful edit so the delta reflects the current tree.

--- a/.ai/skills/compare-slop-scan-delta.yaml
+++ b/.ai/skills/compare-slop-scan-delta.yaml
@@ -14,11 +14,12 @@ requiredEnvironment:
     - Both sides must be comparable inputs, either two checkouts or two JSON reports produced by the scan command.
 inputs:
   required:
-    - basePath: Relative path to the base checkout when comparing trees. Default "../main"
-    - headPath: Relative path to the head checkout when comparing trees. Default "."
+    - comparisonMode: Which input pair to compare, "reports" or "checkouts". Prefer "reports" when both sides are already scanned. Supply the whole pair for the selected mode and do not mix the two.
   optional:
-    - baseReport: Existing base JSON report file, used instead of basePath
-    - headReport: Existing head JSON report file, used instead of headPath
+    - baseReport: Base JSON report file. Required together with headReport in "reports" mode
+    - headReport: Head JSON report file. Required together with baseReport in "reports" mode
+    - basePath: Relative path to the base checkout. Required together with headPath in "checkouts" mode. Default "../main"
+    - headPath: Relative path to the head checkout. Required together with basePath in "checkouts" mode. Default "."
     - baseConfigFile: Relative config path for the base tree when its config lives outside the scan root
     - headConfigFile: Relative config path for the head tree when its config lives outside the scan root
     - failOn: Comma-separated delta statuses that should fail the command, such as "added"
@@ -30,11 +31,16 @@ commands:
     defaults:
       basePath: ../main
       headPath: .
-  - description: Produce the two reports a report comparison needs
-    template: php bin/slop-scan.php scan <scanPath> --config-file <configFile> --json
+  - description: Write the base report that "reports" mode consumes
+    template: php bin/slop-scan.php scan <basePath> --config-file <baseConfigFile> --json > <baseReport>
     defaults:
-      scanPath: .
-      configFile: slop-scan.config.json
+      basePath: ../main
+      baseConfigFile: slop-scan.config.json
+  - description: Write the head report that "reports" mode consumes
+    template: php bin/slop-scan.php scan <headPath> --config-file <headConfigFile> --json > <headReport>
+    defaults:
+      headPath: .
+      headConfigFile: slop-scan.config.json
   - description: Fail the command when a change introduces findings
     template: php bin/slop-scan.php delta --base-report <baseReport> --head-report <headReport> --fail-on added
 expectedOutputs:

--- a/.ai/skills/manifest.yaml
+++ b/.ai/skills/manifest.yaml
@@ -24,3 +24,9 @@ skills:
   - id: interpret-slop-scan-json
     file: .ai/skills/interpret-slop-scan-json.yaml
     summary: Read slop-scan JSON output and turn it into actionable review guidance.
+  - id: compare-slop-scan-delta
+    file: .ai/skills/compare-slop-scan-delta.yaml
+    summary: Compare two scans or reports and report which findings a change added or resolved.
+  - id: summarize-slop-scan-stats
+    file: .ai/skills/summarize-slop-scan-stats.yaml
+    summary: Rank findings by rule and file to decide where a cleanup should start.

--- a/.ai/skills/summarize-slop-scan-stats.yaml
+++ b/.ai/skills/summarize-slop-scan-stats.yaml
@@ -14,10 +14,11 @@ requiredEnvironment:
     - Use an existing JSON report when one is available, so the summary matches the report under review.
 inputs:
   required:
-    - reportSource: Existing JSON report or baseline file, or a scan path when no report exists
+    - inputMode: Which input to summarize, "report" or "scan". Prefer "report" when one exists, so the summary matches the report under review.
   optional:
-    - scanPath: Relative path to scan when no report is provided. Default "."
-    - configFile: Relative config path when scanning. Default "slop-scan.config.json"
+    - reportSource: Existing JSON report or baseline file. Required in "report" mode
+    - scanPath: Relative path to scan. Required in "scan" mode. Default "."
+    - configFile: Relative config path, used in "scan" mode. Default "slop-scan.config.json"
     - topRules: How many rules to list. Default 10
     - topFiles: How many files to list. Default 10
 commands:
@@ -31,7 +32,7 @@ commands:
   - description: Widen the summary when the default lists hide the tail
     template: php bin/slop-scan.php stats --report <reportSource> --top-rules 25 --top-files 25
 expectedOutputs:
-  - JSON with `summary.findingCount`, `summary.uniqueRules`, `summary.uniquePaths`, and `summary.reportKind`, which names the input the summary was built from.
+  - JSON with `summary.findingCount`, `summary.uniqueRules`, `summary.uniquePaths`, and `summary.reportKind`, which reports the report kind read from `metadata.kind`, such as `baseline`, and falls back to `scan` when the input declares no kind.
   - A `topRules` list of `ruleId` with `findingCount` and `locationCount`, plus a `topFiles` list of `path` with `findingCount`.
 failureHandling:
   - The summary ranks findings, it does not explain them. Read the report itself, or use interpret-slop-scan-json, before acting on a ranking.

--- a/.ai/skills/summarize-slop-scan-stats.yaml
+++ b/.ai/skills/summarize-slop-scan-stats.yaml
@@ -1,0 +1,40 @@
+name: summarize-slop-scan-stats
+purpose: Summarize slop-scan findings by rule and file to pick where to start on a large report.
+triggers:
+  - which rules fire most in this repository
+  - summarize slop-scan findings by file
+  - where should cleanup start
+requiredEnvironment:
+  workingDirectory: repository root
+  runtime:
+    - PHP 8.3+
+  tools:
+    - php
+  prerequisites:
+    - Use an existing JSON report when one is available, so the summary matches the report under review.
+inputs:
+  required:
+    - reportSource: Existing JSON report or baseline file, or a scan path when no report exists
+  optional:
+    - scanPath: Relative path to scan when no report is provided. Default "."
+    - configFile: Relative config path when scanning. Default "slop-scan.config.json"
+    - topRules: How many rules to list. Default 10
+    - topFiles: How many files to list. Default 10
+commands:
+  - description: Preferred machine-readable summary of an existing report
+    template: php bin/slop-scan.php stats --report <reportSource> --json
+  - description: Summary of a fresh scan when no report exists yet
+    template: php bin/slop-scan.php stats <scanPath> --config-file <configFile> --json
+    defaults:
+      scanPath: .
+      configFile: slop-scan.config.json
+  - description: Widen the summary when the default lists hide the tail
+    template: php bin/slop-scan.php stats --report <reportSource> --top-rules 25 --top-files 25
+expectedOutputs:
+  - JSON with `summary.findingCount`, `summary.uniqueRules`, `summary.uniquePaths`, and `summary.reportKind`, which names the input the summary was built from.
+  - A `topRules` list of `ruleId` with `findingCount` and `locationCount`, plus a `topFiles` list of `path` with `findingCount`.
+failureHandling:
+  - The summary ranks findings, it does not explain them. Read the report itself, or use interpret-slop-scan-json, before acting on a ranking.
+  - If the report kind is a baseline rather than a scan, remember that baselines carry only suppressed finding metadata, so counts describe what is already accepted.
+  - If a scan path is passed while a report also exists, prefer the report so the summary and the report under review cannot drift apart.
+  - If the summary looks truncated, raise --top-rules and --top-files instead of assuming the tail is empty.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
-## Unreleased
+## 0.1.5 - 2026-08-12
 
+- Added the `compare-slop-scan-delta` portable agent skill, covering both the report-based and checkout-based forms of the `delta` command, the `--fail-on` gate, and the option pairs that are easy to mix up.
+- Added the `summarize-slop-scan-stats` portable agent skill for ranking findings by rule and file before reading a large report in full.
 - Updated dependencies: `voku/simple-php-code-parser` to `^0.22.2`, `nikic/php-parser` to `^5.8`, `helgesverre/toon` to `^3.2`, `phpstan/phpstan` to `^2.2.8`, `phpunit/phpunit` to `^12.5`, and `infection/infection` to `^0.34.2`. `symfony/console` stays on `^7.4` because Symfony 8 requires PHP 8.4 and this package still supports PHP 8.3.
 - Resolved imported PHPDoc types before comparing them with native types, so `use Vendor\Payload as Message;` with `@param Message $message` on a `Payload $message` parameter is no longer reported as a mismatch.
 - Extended `php.misleading-phpdoc-types` to interface, trait, and enum members and to `@var` annotations on typed properties, including every property of a grouped `public string $a, $b;` declaration.

--- a/README.md
+++ b/README.md
@@ -119,3 +119,5 @@ Current portable skills:
 - `scan-php-slop` for deterministic PHP repository scans
 - `validate-slop-scan-repo` for scan-readiness checks and slop-scan troubleshooting on a target PHP repository
 - `interpret-slop-scan-json` for machine-readable report review
+- `compare-slop-scan-delta` for before-and-after comparisons of a change
+- `summarize-slop-scan-stats` for rule and file rankings on large reports


### PR DESCRIPTION
Follow-up to #22, extending the repo-owned agent skills and preparing the 0.1.5 tag.

## Why

The manifest covered scanning, validating, and interpreting a report, but not the two commands an agent reaches for once it has more than one report: `delta` and `stats`. Running the existing loop as a dogfood pass hit that gap directly — `--base` / `--head` take checkouts while `--base-report` / `--head-report` take report files, and nothing recorded which pair belongs to which form. Passing a report file to `--base` fails with a `RecursiveDirectoryIterator ... Not a directory` error that does not hint at the right option.

## What changed

- **`.ai/skills/compare-slop-scan-delta.yaml`** — both forms of the comparison, the `--fail-on` gate with its exit codes (0 without the flag even when findings were added, 1 when a named status is reported), and the option pairs that are easy to confuse.
- **`.ai/skills/summarize-slop-scan-stats.yaml`** — ranking findings by rule and file before reading a large report in full, including `--report` vs. scan-path input and widening the default top-10 lists.
- Both skills name the JSON keys their commands emit (`summary.added` / `summary.resolved` / `changes[].status` for delta; `summary.findingCount` / `topRules[].ruleId` / `topFiles[].path` for stats), so a consumer does not have to guess at the shape.
- Registered both in `.ai/skills/manifest.yaml` and listed them in the README skills section.
- Renamed the pending `## Unreleased` changelog section to `## 0.1.5 - 2026-08-12`, so the tag can sit on this commit the way `0.1.3` and `0.1.4` did.

## Verification

Every command template in both new skills was run against this checkout before being written down, including the documented failure mode. Both skill files were checked against `skillSchema.requiredFields` in the manifest, and all five skills pass.

Full suite on PHP 8.4.19: `composer validate --strict`, `composer run lint`, `composer run analyse` (no errors), `composer run test` (127 tests, 666 assertions), `composer run scan:self` (39 findings, unchanged from main), `composer run phar:build` plus a PHAR smoke test.

## Note on tagging

Docs only — no runtime code changes, so `scan:self` output is identical to main. Once this merges I will push tag `0.1.5` on the merge commit, which triggers `release-phar.yml` and publishes the GitHub Release with the PHAR attached.

---
_Generated by [Claude Code](https://claude.ai/code/session_018jjM3YjguWsnS54jRNNnN7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added portable tools for comparing scan results and identifying newly introduced or resolved findings.
  - Added scan statistics summaries ranked by rule and file, with configurable result limits.
  - Documented runtime requirements, inputs, outputs, and failure handling for both tools.

- **Documentation**
  - Updated the README to list the new capabilities.
  - Released version 0.1.5 with changelog updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->