### PR TITLE
Fix baseline false positives after line-only finding relocation

### DIFF
--- a/src/Delta.php
+++ b/src/Delta.php
@@ -27,28 +27,88 @@ final class Delta
     {
         $baseMap = self::occurrenceMap($base['findings'] ?? []);
         $headMap = self::occurrenceMap($head['findings'] ?? []);
+        $added = array_diff_key($headMap, $baseMap);
+        $resolved = array_diff_key($baseMap, $headMap);
+        [$resolved, $added] = self::withoutUniqueRelocations($resolved, $added);
+
         $changes = [];
-        foreach ($headMap as $fingerprint => $finding) {
-            if (!isset($baseMap[$fingerprint])) {
-                $changes[] = ['status' => 'added', 'fingerprint' => $fingerprint, 'finding' => $finding];
-            }
+        foreach ($added as $fingerprint => $entry) {
+            $changes[] = ['status' => 'added', 'fingerprint' => $fingerprint, 'finding' => $entry['finding']];
         }
-        foreach ($baseMap as $fingerprint => $finding) {
-            if (!isset($headMap[$fingerprint])) {
-                $changes[] = ['status' => 'resolved', 'fingerprint' => $fingerprint, 'finding' => $finding];
-            }
+        foreach ($resolved as $fingerprint => $entry) {
+            $changes[] = ['status' => 'resolved', 'fingerprint' => $fingerprint, 'finding' => $entry['finding']];
         }
         usort($changes, static fn(array $left, array $right): int => strcmp($left['fingerprint'], $right['fingerprint']));
-        return ['summary' => ['added' => count(array_filter($changes, static fn(array $c): bool => $c['status'] === 'added')), 'resolved' => count(array_filter($changes, static fn(array $c): bool => $c['status'] === 'resolved'))], 'changes' => $changes];
+        return ['summary' => ['added' => count($added), 'resolved' => count($resolved)], 'changes' => $changes];
     }
 
-    /** @param list<array<string,mixed>> $findings @return array<string,array<string,mixed>> */
+    /**
+     * @param array<string,array{finding:array<string,mixed>,occurrence:array<string,mixed>}> $resolved
+     * @param array<string,array{finding:array<string,mixed>,occurrence:array<string,mixed>}> $added
+     * @return array{
+     *     array<string,array{finding:array<string,mixed>,occurrence:array<string,mixed>}>,
+     *     array<string,array{finding:array<string,mixed>,occurrence:array<string,mixed>}>
+     * }
+     */
+    private static function withoutUniqueRelocations(array $resolved, array $added): array
+    {
+        $resolvedGroups = self::relocationGroups($resolved);
+        $addedGroups = self::relocationGroups($added);
+        foreach ($resolvedGroups as $key => $resolvedFingerprints) {
+            $addedFingerprints = $addedGroups[$key] ?? [];
+            if (count($resolvedFingerprints) !== 1 || count($addedFingerprints) !== 1) {
+                continue;
+            }
+            unset($resolved[$resolvedFingerprints[0]], $added[$addedFingerprints[0]]);
+        }
+
+        return [$resolved, $added];
+    }
+
+    /**
+     * @param array<string,array{finding:array<string,mixed>,occurrence:array<string,mixed>}> $occurrences
+     * @return array<string,list<string>>
+     */
+    private static function relocationGroups(array $occurrences): array
+    {
+        $groups = [];
+        foreach ($occurrences as $fingerprint => $entry) {
+            $groups[self::relocationKey($entry)][] = $fingerprint;
+        }
+
+        return $groups;
+    }
+
+    /** @param array{finding:array<string,mixed>,occurrence:array<string,mixed>} $entry */
+    private static function relocationKey(array $entry): string
+    {
+        $finding = $entry['finding'];
+        $occurrence = $entry['occurrence'];
+        $evidence = array_values(array_filter(
+            is_array($finding['evidence'] ?? null) ? $finding['evidence'] : [],
+            'is_string',
+        ));
+
+        return hash('sha256', json_encode([
+            'rule_id' => $finding['ruleId'] ?? '',
+            'family' => $finding['family'] ?? '',
+            'scope' => $finding['scope'] ?? '',
+            'message' => $finding['message'] ?? '',
+            'path' => $occurrence['path'] ?? $finding['path'] ?? '<repo>',
+            'evidence' => $evidence,
+        ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+    }
+
+    /**
+     * @param list<array<string,mixed>> $findings
+     * @return array<string,array{finding:array<string,mixed>,occurrence:array<string,mixed>}>
+     */
     private static function occurrenceMap(array $findings): array
     {
         $map = [];
         foreach ($findings as $finding) {
             foreach (($finding['deltaIdentity']['occurrences'] ?? []) as $occurrence) {
-                $map[$occurrence['fingerprint']] = $finding;
+                $map[$occurrence['fingerprint']] = ['finding' => $finding, 'occurrence' => $occurrence];
             }
         }
         ksort($map, SORT_STRING);

--- a/tests/DeltaTest.php
+++ b/tests/DeltaTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SlopScan\Tests;
+
+use PHPUnit\Framework\TestCase;
+use SlopScan\Delta;
+use SlopScan\Model\Finding;
+
+final class DeltaTest extends TestCase
+{
+    public function testUniqueSemanticFindingCanMoveWithoutBecomingNew(): void
+    {
+        $delta = Delta::diff(
+            ['findings' => [$this->finding(10)]],
+            ['findings' => [$this->finding(16)]],
+        );
+
+        self::assertSame(['added' => 0, 'resolved' => 0], $delta['summary']);
+        self::assertSame([], $delta['changes']);
+    }
+
+    public function testChangedEvidenceDoesNotMasqueradeAsRelocation(): void
+    {
+        $delta = Delta::diff(
+            ['findings' => [$this->finding(10, 'return=null')]],
+            ['findings' => [$this->finding(16, 'return=false')]],
+        );
+
+        self::assertSame(['added' => 1, 'resolved' => 1], $delta['summary']);
+        self::assertCount(2, $delta['changes']);
+    }
+
+    public function testAmbiguousDuplicateRelocationsRemainExactMatchOnly(): void
+    {
+        $delta = Delta::diff(
+            ['findings' => [$this->finding(10), $this->finding(20)]],
+            ['findings' => [$this->finding(16), $this->finding(26)]],
+        );
+
+        self::assertSame(['added' => 2, 'resolved' => 2], $delta['summary']);
+        self::assertCount(4, $delta['changes']);
+    }
+
+    /** @return array<string, mixed> */
+    private function finding(int $line, string $evidence = 'return=null'): array
+    {
+        return (new Finding(
+            ruleId: 'php.catch-default-fallbacks',
+            family: 'error-handling',
+            severity: 'medium',
+            scope: 'file',
+            message: 'Found PHP catch block that returns a default fallback literal',
+            evidence: [$evidence],
+            score: 2,
+            locations: [[
+                'path' => 'src/Workflow/WorkflowContextCommand.php',
+                'line' => $line,
+                'column' => 1,
+            ]],
+            path: 'src/Workflow/WorkflowContextCommand.php',
+        ))->toReport();
+    }
+}


### PR DESCRIPTION
Real dogfood from `voku/agent-loop#81` exposed a delta-identity false positive: adding six unrelated lines before two unchanged findings made both look resolved+new because fingerprint v1 includes the line number.

This keeps exact fingerprints as primary identity and only cancels an unmatched resolved/added pair when `rule + message + occurrence path + evidence` is uniquely 1:1. Ambiguous duplicates remain exact-match-only.

Tests cover pure relocation, changed evidence, and ambiguous duplicate relocation. No report/baseline schema or fingerprint-version change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved change reporting when identical findings move between locations.
  * Prevented relocated findings from being incorrectly reported as newly added or resolved.
  * Findings with changed evidence are now correctly recognized as changes rather than relocations.
  * Ambiguous duplicate relocations continue to be reported accurately without assumptions.
  * Updated summary counts to reflect the corrected results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->