### PR TITLE
Build PHAR dependencies against minimum supported PHP

### DIFF
--- a/build/build-phar.php
+++ b/build/build-phar.php
@@ -45,6 +45,7 @@ try {
         }
     }
 
+    runCommand(['composer', 'config', 'platform.php', '8.3.0'], $buildDir);
     runCommand(
         ['composer', 'install', '--no-dev', '--prefer-dist', '--no-interaction', '--optimize-autoloader', '--no-scripts'],
         $buildDir,


### PR DESCRIPTION
Closes #30.

Real downstream dogfood showed that the 0.1.6 PHAR, built on PHP 8.4 without a repository lockfile, embedded a dependency tree requiring PHP >=8.4.1 even though slop-scan declares PHP ^8.3.

The PHAR builder now sets Composer's temporary build platform to PHP 8.3.0 before resolving runtime dependencies. Source-package dependency policy stays unchanged; only binary packaging is made deterministic against the declared minimum platform.

Production diff: one added command, no dependency downgrades or workflow redesign.

The normal CI already builds and starts the produced PHAR, so this candidate must pass the same binary path before merge.