### PR TITLE
feat: detect duplicated PHPUnit mock setup shapes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "php": "^8.3",
         "nikic/php-parser": "^5.8",
         "symfony/console": "^7.4",
-        "voku/simple-php-code-parser": "^0.22.2",
+        "voku/simple-php-code-parser": "^0.22.3",
         "helgesverre/toon": "^3.2"
     },
     "require-dev": {

--- a/src/DefaultRegistry.php
+++ b/src/DefaultRegistry.php
@@ -22,6 +22,7 @@ use SlopScan\Rule\CatchDefaultFallbacksRule;
 use SlopScan\Rule\DebugOutputRule;
 use SlopScan\Rule\DirectoryFanoutHotspotRule;
 use SlopScan\Rule\DuplicateFunctionSignaturesRule;
+use SlopScan\Rule\DuplicateMockSetupRule;
 use SlopScan\Rule\EmptyCatchRule;
 use SlopScan\Rule\ExceptionWrapWithoutPreviousRule;
 use SlopScan\Rule\ErrorObscuringCatchRule;
@@ -72,6 +73,7 @@ final class DefaultRegistry
             new DirectoryFanoutHotspotRule(),
             new OverFragmentationRule(),
             new DuplicateFunctionSignaturesRule(),
+            new DuplicateMockSetupRule(),
             new ReturnConstantStubRule(),
             new PlaceholderMethodBodiesRule(),
             new CloneClusterRule(),

--- a/src/Fact/FunctionDuplicationFactProvider.php
+++ b/src/Fact/FunctionDuplicationFactProvider.php
@@ -20,14 +20,16 @@ final class FunctionDuplicationFactProvider implements FactProvider
 
     public function id(): string { return 'repo.functionDuplication'; }
     public function scope(): string { return 'repo'; }
-    public function requires(): array { return ['repo.files', 'file.functionSummaries']; }
-    public function provides(): array { return ['repo.duplicateFunctionSignatures', 'repo.cloneFunctionBodies']; }
+    public function requires(): array { return ['repo.files', 'file.functionSummaries', 'file.testMockSetups']; }
+    public function provides(): array { return ['repo.duplicateFunctionSignatures', 'repo.cloneFunctionBodies', 'repo.duplicateMockSetups']; }
     public function supports(ProviderContext $context): bool { return true; }
 
     public function run(ProviderContext $context): array
     {
         $signatureGroups = [];
         $bodyGroups = [];
+        /** @var array<string,array{fingerprint:string,label:string,occurrences:list<array{path:string,line:int}>}> $mockSetupGroups */
+        $mockSetupGroups = [];
 
         foreach ($context->runtime->files as $file) {
             foreach ($context->runtime->store->getFileFact($file->path, 'file.functionSummaries') ?? [] as $function) {
@@ -49,6 +51,30 @@ final class FunctionDuplicationFactProvider implements FactProvider
                     ];
                 }
             }
+
+            if (!self::looksLikeTestPath($file->path)) {
+                continue;
+            }
+
+            foreach ($context->runtime->store->getFileFact($file->path, 'file.testMockSetups') ?? [] as $setup) {
+                if (!is_array($setup)) {
+                    continue;
+                }
+
+                $fingerprint = $setup['fingerprint'] ?? null;
+                $label = $setup['label'] ?? null;
+                $line = $setup['line'] ?? null;
+                if (!is_string($fingerprint) || $fingerprint === '' || !is_string($label) || !is_int($line)) {
+                    continue;
+                }
+
+                $mockSetupGroups[$fingerprint] ??= [
+                    'fingerprint' => $fingerprint,
+                    'label' => $label,
+                    'occurrences' => [],
+                ];
+                $mockSetupGroups[$fingerprint]['occurrences'][] = ['path' => $file->path, 'line' => $line];
+            }
         }
 
         $duplicateSignatures = array_filter($signatureGroups, static fn(array $group): bool => count($group) > 1);
@@ -57,9 +83,40 @@ final class FunctionDuplicationFactProvider implements FactProvider
         $cloneBodies = array_filter($bodyGroups, static fn(array $group): bool => count($group) > 1);
         ksort($cloneBodies, SORT_STRING);
 
+        /** @var list<array{fingerprint:string,label:string,fileCount:int,occurrences:list<array{path:string,line:int}>}> $duplicateMockSetups */
+        $duplicateMockSetups = [];
+        foreach ($mockSetupGroups as $group) {
+            $filePaths = array_values(array_unique(array_column($group['occurrences'], 'path')));
+            if (count($filePaths) < 3) {
+                continue;
+            }
+
+            usort(
+                $group['occurrences'],
+                static fn (array $left, array $right): int => strcmp($left['path'], $right['path']) ?: ($left['line'] <=> $right['line']),
+            );
+            $duplicateMockSetups[] = [
+                'fingerprint' => $group['fingerprint'],
+                'label' => $group['label'],
+                'fileCount' => count($filePaths),
+                'occurrences' => $group['occurrences'],
+            ];
+        }
+        usort(
+            $duplicateMockSetups,
+            static fn (array $left, array $right): int => ($right['fileCount'] <=> $left['fileCount'])
+                ?: strcmp($left['fingerprint'], $right['fingerprint']),
+        );
+
         return [
             'repo.duplicateFunctionSignatures' => $duplicateSignatures,
             'repo.cloneFunctionBodies' => $cloneBodies,
+            'repo.duplicateMockSetups' => $duplicateMockSetups,
         ];
+    }
+
+    private static function looksLikeTestPath(string $path): bool
+    {
+        return preg_match('#(?:^|/)(?:tests?|spec)(?:/|$)|(?:Test|TestCase)\.php$#i', str_replace('\\', '/', $path)) === 1;
     }
 }

--- a/src/Fact/FunctionDuplicationFactProvider.php
+++ b/src/Fact/FunctionDuplicationFactProvider.php
@@ -52,10 +52,6 @@ final class FunctionDuplicationFactProvider implements FactProvider
                 }
             }
 
-            if (!self::looksLikeTestPath($file->path)) {
-                continue;
-            }
-
             foreach ($context->runtime->store->getFileFact($file->path, 'file.testMockSetups') ?? [] as $setup) {
                 if (!is_array($setup)) {
                     continue;
@@ -113,10 +109,5 @@ final class FunctionDuplicationFactProvider implements FactProvider
             'repo.cloneFunctionBodies' => $cloneBodies,
             'repo.duplicateMockSetups' => $duplicateMockSetups,
         ];
-    }
-
-    private static function looksLikeTestPath(string $path): bool
-    {
-        return preg_match('#(?:^|/)(?:tests?|spec)(?:/|$)|(?:Test|TestCase)\.php$#i', str_replace('\\', '/', $path)) === 1;
     }
 }

--- a/src/Fact/PhpFacts.php
+++ b/src/Fact/PhpFacts.php
@@ -12,6 +12,8 @@ use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\NodeFinder;
 use PhpParser\Node\Stmt;
+use PhpParser\Parser;
+use PhpParser\ParserFactory;
 use PhpParser\PrettyPrinter\Standard;
 use voku\SimplePhpParser\Model\PHPClass;
 use voku\SimplePhpParser\Model\PHPEnum;
@@ -40,6 +42,9 @@ final class PhpFacts
         'underflowexception',
         'unexpectedvalueexception',
     ];
+
+    /** @var null|callable():Parser */
+    private static $parserFactory = null;
 
     /** @return list<array{text:string,line:int}> */
     public static function comments(string $text): array
@@ -145,7 +150,9 @@ final class PhpFacts
         return $entries;
     }
 
-    /** @return array{mixedTypeCount:int,castCount:int} */
+    /**
+     * @return array{mixedTypeCount:int,castCount:int}
+     */
     public static function typeEscapeSummary(string $text): array
     {
         $statements = self::parseStatements($text);
@@ -247,10 +254,18 @@ final class PhpFacts
         ];
     }
 
+    /**
+     * @param null|callable():Parser $parserFactory Factory returning a nikic/php-parser parser instance.
+     */
+    public static function useParserFactoryForTesting(?callable $parserFactory): void
+    {
+        self::$parserFactory = $parserFactory;
+    }
+
     /** @return array{available:bool,classCount:int,functionCount:int,error?:string} */
     public static function parserSummary(string $absolutePath): array
     {
-        if (!class_exists(PhpCodeParser::class)) {
+        if (self::$parserFactory === null && !class_exists(ParserFactory::class)) {
             return ['available' => false, 'classCount' => 0, 'functionCount' => 0];
         }
 
@@ -260,7 +275,7 @@ final class PhpFacts
         }
 
         try {
-            $statements = PhpCodeParser::getAstFromString($text);
+            $statements = self::parser()->parse($text) ?? [];
             $finder = self::nodeFinder();
             $classCount = count($finder->find($statements, static fn(Node $node): bool => $node instanceof Stmt\Class_ || $node instanceof Stmt\Interface_ || $node instanceof Stmt\Trait_ || $node instanceof Stmt\Enum_));
             $functionCount = count($finder->findInstanceOf($statements, Stmt\Function_::class));
@@ -346,12 +361,17 @@ final class PhpFacts
     private static function parseStatements(string $text): ?array
     {
         try {
-            $statements = PhpCodeParser::getAstFromString($text);
-            /** @var list<Stmt> $statements */
-            return $statements;
+            return self::parser()->parse($text) ?? [];
         } catch (\Throwable) {
             return null;
         }
+    }
+
+    private static function parser(): Parser
+    {
+        return self::$parserFactory !== null
+            ? (self::$parserFactory)()
+            : (new ParserFactory())->createForHostVersion();
     }
 
     private static function nodeFinder(): NodeFinder
@@ -369,7 +389,9 @@ final class PhpFacts
         return trim((new Standard())->prettyPrint($statements));
     }
 
-    /** @return list<list<Stmt>> */
+    /**
+     * @return list<list<Stmt>>
+     */
     private static function childStatements(Node $node): array
     {
         $children = [];
@@ -781,7 +803,9 @@ final class PhpFacts
         return '$' . $arg->value->name;
     }
 
-    /** @return null|array{value:string,normalized:string,kind:string,line:int,column:int} */
+    /**
+     * @return null|array{value:string,normalized:string,kind:string,line:int,column:int}
+     */
     private static function magicNumberCandidate(Node $node, ?Node $parent, string $text): ?array
     {
         if ($node instanceof Node\Scalar\String_) {
@@ -888,7 +912,9 @@ final class PhpFacts
         return substr($text, $start, $end - $start + 1);
     }
 
-    /** @param callable(Node, ?Node): bool $visitor */
+    /**
+     * @param callable(Node, ?Node): bool $visitor
+     */
     private static function walkNodes(mixed $value, ?Node $parent, callable $visitor): void
     {
         if ($value instanceof Node) {
@@ -1049,7 +1075,9 @@ final class PhpFacts
         return null;
     }
 
-    /** @return array{class:?string,isGeneric:bool,preservesPrevious:bool,usesCaughtVariable:bool} */
+    /**
+     * @return array{class:?string,isGeneric:bool,preservesPrevious:bool,usesCaughtVariable:bool}
+     */
     private static function thrownExceptionSummary(Expr\Throw_ $throw, ?string $catchVariableName): array
     {
         if (!$throw->expr instanceof Expr\New_) {
@@ -1074,7 +1102,9 @@ final class PhpFacts
         ];
     }
 
-    /** @param list<Arg> $args */
+    /**
+     * @param list<Arg> $args
+     */
     private static function callUsesVariable(array $args, string $variableName): bool
     {
         foreach ($args as $arg) {

--- a/src/Fact/PhpFacts.php
+++ b/src/Fact/PhpFacts.php
@@ -12,8 +12,6 @@ use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\NodeFinder;
 use PhpParser\Node\Stmt;
-use PhpParser\Parser;
-use PhpParser\ParserFactory;
 use PhpParser\PrettyPrinter\Standard;
 use voku\SimplePhpParser\Model\PHPClass;
 use voku\SimplePhpParser\Model\PHPEnum;
@@ -42,9 +40,6 @@ final class PhpFacts
         'underflowexception',
         'unexpectedvalueexception',
     ];
-
-    /** @var null|callable():Parser */
-    private static $parserFactory = null;
 
     /** @return list<array{text:string,line:int}> */
     public static function comments(string $text): array
@@ -150,9 +145,7 @@ final class PhpFacts
         return $entries;
     }
 
-    /**
-     * @return array{mixedTypeCount:int,castCount:int}
-     */
+    /** @return array{mixedTypeCount:int,castCount:int} */
     public static function typeEscapeSummary(string $text): array
     {
         $statements = self::parseStatements($text);
@@ -254,18 +247,10 @@ final class PhpFacts
         ];
     }
 
-    /**
-     * @param null|callable():Parser $parserFactory Factory returning a nikic/php-parser parser instance.
-     */
-    public static function useParserFactoryForTesting(?callable $parserFactory): void
-    {
-        self::$parserFactory = $parserFactory;
-    }
-
     /** @return array{available:bool,classCount:int,functionCount:int,error?:string} */
     public static function parserSummary(string $absolutePath): array
     {
-        if (self::$parserFactory === null && !class_exists(ParserFactory::class)) {
+        if (!class_exists(PhpCodeParser::class)) {
             return ['available' => false, 'classCount' => 0, 'functionCount' => 0];
         }
 
@@ -275,7 +260,7 @@ final class PhpFacts
         }
 
         try {
-            $statements = self::parser()->parse($text) ?? [];
+            $statements = PhpCodeParser::getAstFromString($text);
             $finder = self::nodeFinder();
             $classCount = count($finder->find($statements, static fn(Node $node): bool => $node instanceof Stmt\Class_ || $node instanceof Stmt\Interface_ || $node instanceof Stmt\Trait_ || $node instanceof Stmt\Enum_));
             $functionCount = count($finder->findInstanceOf($statements, Stmt\Function_::class));
@@ -361,17 +346,12 @@ final class PhpFacts
     private static function parseStatements(string $text): ?array
     {
         try {
-            return self::parser()->parse($text) ?? [];
+            $statements = PhpCodeParser::getAstFromString($text);
+            /** @var list<Stmt> $statements */
+            return $statements;
         } catch (\Throwable) {
             return null;
         }
-    }
-
-    private static function parser(): Parser
-    {
-        return self::$parserFactory !== null
-            ? (self::$parserFactory)()
-            : (new ParserFactory())->createForHostVersion();
     }
 
     private static function nodeFinder(): NodeFinder
@@ -389,9 +369,7 @@ final class PhpFacts
         return trim((new Standard())->prettyPrint($statements));
     }
 
-    /**
-     * @return list<list<Stmt>>
-     */
+    /** @return list<list<Stmt>> */
     private static function childStatements(Node $node): array
     {
         $children = [];
@@ -803,9 +781,7 @@ final class PhpFacts
         return '$' . $arg->value->name;
     }
 
-    /**
-     * @return null|array{value:string,normalized:string,kind:string,line:int,column:int}
-     */
+    /** @return null|array{value:string,normalized:string,kind:string,line:int,column:int} */
     private static function magicNumberCandidate(Node $node, ?Node $parent, string $text): ?array
     {
         if ($node instanceof Node\Scalar\String_) {
@@ -912,9 +888,7 @@ final class PhpFacts
         return substr($text, $start, $end - $start + 1);
     }
 
-    /**
-     * @param callable(Node, ?Node): bool $visitor
-     */
+    /** @param callable(Node, ?Node): bool $visitor */
     private static function walkNodes(mixed $value, ?Node $parent, callable $visitor): void
     {
         if ($value instanceof Node) {
@@ -1075,9 +1049,7 @@ final class PhpFacts
         return null;
     }
 
-    /**
-     * @return array{class:?string,isGeneric:bool,preservesPrevious:bool,usesCaughtVariable:bool}
-     */
+    /** @return array{class:?string,isGeneric:bool,preservesPrevious:bool,usesCaughtVariable:bool} */
     private static function thrownExceptionSummary(Expr\Throw_ $throw, ?string $catchVariableName): array
     {
         if (!$throw->expr instanceof Expr\New_) {
@@ -1102,9 +1074,7 @@ final class PhpFacts
         ];
     }
 
-    /**
-     * @param list<Arg> $args
-     */
+    /** @param list<Arg> $args */
     private static function callUsesVariable(array $args, string $variableName): bool
     {
         foreach ($args as $arg) {

--- a/src/Fact/PhpRulePortFacts.php
+++ b/src/Fact/PhpRulePortFacts.php
@@ -282,38 +282,117 @@ final class PhpRulePortFacts
     private static function testMockSetups(array $statements, NodeFinder $finder): array
     {
         $setups = [];
-        foreach ($finder->findInstanceOf($statements, Stmt\Expression::class) as $statement) {
-            $methods = [];
-            foreach ($finder->findInstanceOf([$statement->expr], Expr\MethodCall::class) as $call) {
-                if (!$call->name instanceof Identifier) {
+
+        foreach ($finder->findInstanceOf($statements, Stmt\ClassMethod::class) as $method) {
+            $mockVariables = [];
+
+            foreach ($method->stmts ?? [] as $statement) {
+                if (!$statement instanceof Stmt\Expression) {
                     continue;
                 }
 
-                $name = strtolower($call->name->toString());
-                if (in_array($name, ['method', 'willreturn', 'getmockbuilder', 'getmock'], true)) {
-                    $methods[$name] = true;
+                $assignedVariable = self::assignedVariableName($statement->expr);
+                if ($assignedVariable !== null) {
+                    if (self::createdMockVariable($statement->expr) !== null) {
+                        $mockVariables[$assignedVariable] = true;
+                    } else {
+                        unset($mockVariables[$assignedVariable]);
+                    }
                 }
-            }
 
-            $label = null;
-            if (isset($methods['method'], $methods['willreturn'])) {
-                $label = 'method|willReturn';
-            } elseif (isset($methods['getmockbuilder'], $methods['getmock'])) {
-                $label = 'getMockBuilder|getMock';
-            }
+                $label = null;
+                $configuredMockVariable = self::configuredMockVariable($statement->expr);
+                if ($configuredMockVariable !== null && isset($mockVariables[$configuredMockVariable])) {
+                    $label = 'method|willReturn';
+                } elseif (self::hasMockBuilderChain($statement->expr, $finder)) {
+                    $label = 'getMockBuilder|getMock';
+                }
 
-            if ($label === null) {
-                continue;
-            }
+                if ($label === null) {
+                    continue;
+                }
 
-            $setups[] = [
-                'label' => $label,
-                'fingerprint' => $label . '::' . AstNodeInspector::shapeFingerprint($statement, 5),
-                'line' => $statement->getStartLine(),
-            ];
+                $setups[] = [
+                    'label' => $label,
+                    'fingerprint' => $label . '::' . AstNodeInspector::shapeFingerprint($statement, 5),
+                    'line' => $statement->getStartLine(),
+                ];
+            }
         }
 
         return $setups;
+    }
+
+    private static function assignedVariableName(Expr $expr): ?string
+    {
+        if (!$expr instanceof Expr\Assign
+            || !$expr->var instanceof Expr\Variable
+            || !is_string($expr->var->name)
+        ) {
+            return null;
+        }
+
+        return $expr->var->name;
+    }
+
+    private static function createdMockVariable(Expr $expr): ?string
+    {
+        $variable = self::assignedVariableName($expr);
+        if ($variable === null || !$expr instanceof Expr\Assign || !$expr->expr instanceof Expr\MethodCall) {
+            return null;
+        }
+
+        $call = $expr->expr;
+        if (!$call->name instanceof Identifier
+            || strtolower($call->name->toString()) !== 'createmock'
+            || !$call->var instanceof Expr\Variable
+            || $call->var->name !== 'this'
+        ) {
+            return null;
+        }
+
+        return $variable;
+    }
+
+    private static function configuredMockVariable(Expr $expr): ?string
+    {
+        if (!$expr instanceof Expr\MethodCall
+            || !$expr->name instanceof Identifier
+            || strtolower($expr->name->toString()) !== 'willreturn'
+            || !$expr->var instanceof Expr\MethodCall
+            || !$expr->var->name instanceof Identifier
+            || strtolower($expr->var->name->toString()) !== 'method'
+        ) {
+            return null;
+        }
+
+        return self::rootVariableName($expr->var->var);
+    }
+
+    private static function rootVariableName(Expr $expr): ?string
+    {
+        while ($expr instanceof Expr\MethodCall) {
+            $expr = $expr->var;
+        }
+
+        return $expr instanceof Expr\Variable && is_string($expr->name) ? $expr->name : null;
+    }
+
+    private static function hasMockBuilderChain(Expr $expr, NodeFinder $finder): bool
+    {
+        $methods = [];
+        foreach ($finder->findInstanceOf([$expr], Expr\MethodCall::class) as $call) {
+            if (!$call->name instanceof Identifier) {
+                continue;
+            }
+
+            $name = strtolower($call->name->toString());
+            if ($name === 'getmockbuilder' || $name === 'getmock') {
+                $methods[$name] = true;
+            }
+        }
+
+        return isset($methods['getmockbuilder'], $methods['getmock']);
     }
 
     /** @return list<CaughtExceptionNormalization> */

--- a/src/Fact/PhpRulePortFacts.php
+++ b/src/Fact/PhpRulePortFacts.php
@@ -11,10 +11,7 @@ use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
 use PhpParser\NodeFinder;
-use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitor\ParentConnectingVisitor;
-use PhpParser\Parser;
-use PhpParser\ParserFactory;
+use voku\SimplePhpParser\Parsers\PhpCodeParser;
 
 /**
  * AST facts used only by PHP adaptations of upstream rules.
@@ -535,18 +532,12 @@ final class PhpRulePortFacts
     private static function parseStatementsWithParents(string $text): ?array
     {
         try {
-            $statements = self::parser()->parse($text) ?? [];
-            $withParents = (new NodeTraverser(new ParentConnectingVisitor()))->traverse($statements);
-            /** @var list<Stmt> $withParents */
-            return $withParents;
+            $statements = PhpCodeParser::getAstFromString($text);
+            /** @var list<Stmt> $statements */
+            return $statements;
         } catch (\Throwable) {
             return null;
         }
-    }
-
-    private static function parser(): Parser
-    {
-        return (new ParserFactory())->createForHostVersion();
     }
 
     private static function parent(Node $node): ?Node

--- a/src/Fact/PhpRulePortFacts.php
+++ b/src/Fact/PhpRulePortFacts.php
@@ -70,7 +70,7 @@ final class PhpRulePortFacts
     ];
 
     /** @return Summary */
-    public static function summarize(string $text): array
+    public static function summarize(string $text, bool $includeTestMockSetups = false): array
     {
         $statements = self::parseStatementsWithParents($text);
         if ($statements === null) {
@@ -106,7 +106,7 @@ final class PhpRulePortFacts
             }
         }
 
-        $testMockSetups = self::testMockSetups($statements, $finder);
+        $testMockSetups = $includeTestMockSetups ? self::testMockSetups($statements, $finder) : [];
 
         usort(
             $genericArrayCasts,

--- a/src/Fact/PhpRulePortFacts.php
+++ b/src/Fact/PhpRulePortFacts.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
 use PhpParser\NodeFinder;
+use voku\SimplePhpParser\Parsers\Helper\AstNodeInspector;
 use voku\SimplePhpParser\Parsers\PhpCodeParser;
 
 /**
@@ -158,7 +159,7 @@ final class PhpRulePortFacts
             'variable' => '$' . $assign->var->name,
             'kind' => $kind,
             'line' => $assign->expr->getStartLine(),
-            'column' => self::nodeStartColumn($assign->expr, $text),
+            'column' => AstNodeInspector::startColumn($assign->expr, $text),
         ];
     }
 
@@ -233,7 +234,7 @@ final class PhpRulePortFacts
             'payloadKeys' => $keys,
             'kind' => self::statusEnvelopeContextKind($array),
             'line' => $array->getStartLine(),
-            'column' => self::nodeStartColumn($array, $text),
+            'column' => AstNodeInspector::startColumn($array, $text),
         ];
     }
 
@@ -307,41 +308,12 @@ final class PhpRulePortFacts
 
             $setups[] = [
                 'label' => $label,
-                'fingerprint' => $label . '::' . self::fingerprintNodeShape($statement),
+                'fingerprint' => $label . '::' . AstNodeInspector::shapeFingerprint($statement, 5),
                 'line' => $statement->getStartLine(),
             ];
         }
 
         return $setups;
-    }
-
-    private static function fingerprintNodeShape(Node $node, int $depth = 0): string
-    {
-        $label = $node->getType();
-        if ($depth >= 5) {
-            return $label;
-        }
-
-        $children = [];
-        foreach ($node->getSubNodeNames() as $name) {
-            $value = $node->$name;
-            if ($value instanceof Node) {
-                $children[] = self::fingerprintNodeShape($value, $depth + 1);
-                continue;
-            }
-
-            if (!is_array($value)) {
-                continue;
-            }
-
-            foreach ($value as $child) {
-                if ($child instanceof Node) {
-                    $children[] = self::fingerprintNodeShape($child, $depth + 1);
-                }
-            }
-        }
-
-        return $children === [] ? $label : $label . '(' . implode(',', $children) . ')';
     }
 
     /** @return list<CaughtExceptionNormalization> */
@@ -509,7 +481,7 @@ final class PhpRulePortFacts
         return [
             'kind' => $kind,
             'line' => $expr->getStartLine(),
-            'column' => self::nodeStartColumn($expr, $text),
+            'column' => AstNodeInspector::startColumn($expr, $text),
         ];
     }
 
@@ -545,18 +517,5 @@ final class PhpRulePortFacts
         $parent = $node->getAttribute('parent');
 
         return $parent instanceof Node ? $parent : null;
-    }
-
-    private static function nodeStartColumn(Node $node, string $text): int
-    {
-        $start = $node->getStartFilePos();
-        if ($start < 0) {
-            return 1;
-        }
-
-        $prefix = substr($text, 0, $start);
-        $lineStart = strrpos($prefix, "\n");
-
-        return $lineStart === false ? $start + 1 : $start - $lineStart;
     }
 }

--- a/src/Fact/PhpRulePortFacts.php
+++ b/src/Fact/PhpRulePortFacts.php
@@ -22,10 +22,12 @@ use PhpParser\ParserFactory;
  * @phpstan-type GenericArrayCast array{variable:string,kind:string,line:int,column:int}
  * @phpstan-type CaughtExceptionNormalization array{kind:string,line:int,column:int}
  * @phpstan-type StatusEnvelope array{statusKey:string,statusValue:string,payloadKeys:list<string>,kind:string,line:int,column:int}
+ * @phpstan-type TestMockSetup array{label:string,fingerprint:string,line:int}
  * @phpstan-type Summary array{
  *     genericArrayCasts:list<GenericArrayCast>,
  *     caughtExceptionNormalizations:list<CaughtExceptionNormalization>,
- *     statusEnvelopes:list<StatusEnvelope>
+ *     statusEnvelopes:list<StatusEnvelope>,
+ *     testMockSetups:list<TestMockSetup>
  * }
  */
 final class PhpRulePortFacts
@@ -76,6 +78,7 @@ final class PhpRulePortFacts
                 'genericArrayCasts' => [],
                 'caughtExceptionNormalizations' => [],
                 'statusEnvelopes' => [],
+                'testMockSetups' => [],
             ];
         }
 
@@ -103,6 +106,8 @@ final class PhpRulePortFacts
             }
         }
 
+        $testMockSetups = self::testMockSetups($statements, $finder);
+
         usort(
             $genericArrayCasts,
             static fn (array $left, array $right): int => ($left['line'] <=> $right['line'])
@@ -121,11 +126,17 @@ final class PhpRulePortFacts
                 ?: ($left['column'] <=> $right['column'])
                 ?: strcmp($left['statusKey'], $right['statusKey']),
         );
+        usort(
+            $testMockSetups,
+            static fn (array $left, array $right): int => ($left['line'] <=> $right['line'])
+                ?: strcmp($left['fingerprint'], $right['fingerprint']),
+        );
 
         return [
             'genericArrayCasts' => $genericArrayCasts,
             'caughtExceptionNormalizations' => self::uniqueNormalizations($caughtExceptionNormalizations),
             'statusEnvelopes' => $statusEnvelopes,
+            'testMockSetups' => $testMockSetups,
         ];
     }
 
@@ -267,6 +278,73 @@ final class PhpRulePortFacts
         }
 
         return 'assigned-generic-status-envelope';
+    }
+
+    /** @param list<Stmt> $statements @return list<TestMockSetup> */
+    private static function testMockSetups(array $statements, NodeFinder $finder): array
+    {
+        $setups = [];
+        foreach ($finder->findInstanceOf($statements, Stmt\Expression::class) as $statement) {
+            $methods = [];
+            foreach ($finder->findInstanceOf([$statement->expr], Expr\MethodCall::class) as $call) {
+                if (!$call->name instanceof Identifier) {
+                    continue;
+                }
+
+                $name = strtolower($call->name->toString());
+                if (in_array($name, ['method', 'willreturn', 'getmockbuilder', 'getmock'], true)) {
+                    $methods[$name] = true;
+                }
+            }
+
+            $label = null;
+            if (isset($methods['method'], $methods['willreturn'])) {
+                $label = 'method|willReturn';
+            } elseif (isset($methods['getmockbuilder'], $methods['getmock'])) {
+                $label = 'getMockBuilder|getMock';
+            }
+
+            if ($label === null) {
+                continue;
+            }
+
+            $setups[] = [
+                'label' => $label,
+                'fingerprint' => $label . '::' . self::fingerprintNodeShape($statement),
+                'line' => $statement->getStartLine(),
+            ];
+        }
+
+        return $setups;
+    }
+
+    private static function fingerprintNodeShape(Node $node, int $depth = 0): string
+    {
+        $label = $node->getType();
+        if ($depth >= 5) {
+            return $label;
+        }
+
+        $children = [];
+        foreach ($node->getSubNodeNames() as $name) {
+            $value = $node->$name;
+            if ($value instanceof Node) {
+                $children[] = self::fingerprintNodeShape($value, $depth + 1);
+                continue;
+            }
+
+            if (!is_array($value)) {
+                continue;
+            }
+
+            foreach ($value as $child) {
+                if ($child instanceof Node) {
+                    $children[] = self::fingerprintNodeShape($child, $depth + 1);
+                }
+            }
+        }
+
+        return $children === [] ? $label : $label . '(' . implode(',', $children) . ')';
     }
 
     /** @return list<CaughtExceptionNormalization> */

--- a/src/Fact/PhpStructureFactProvider.php
+++ b/src/Fact/PhpStructureFactProvider.php
@@ -26,6 +26,7 @@ final class PhpStructureFactProvider implements FactProvider
             'file.statusEnvelopes',
             'file.genericArrayCasts',
             'file.caughtExceptionNormalizations',
+            'file.testMockSetups',
         ];
     }
     public function supports(ProviderContext $context): bool { return $context->file?->languageId === 'php'; }
@@ -47,6 +48,7 @@ final class PhpStructureFactProvider implements FactProvider
             'file.statusEnvelopes' => $rulePortFacts['statusEnvelopes'],
             'file.genericArrayCasts' => $rulePortFacts['genericArrayCasts'],
             'file.caughtExceptionNormalizations' => $rulePortFacts['caughtExceptionNormalizations'],
+            'file.testMockSetups' => $rulePortFacts['testMockSetups'],
         ];
     }
 }

--- a/src/Fact/PhpStructureFactProvider.php
+++ b/src/Fact/PhpStructureFactProvider.php
@@ -34,7 +34,8 @@ final class PhpStructureFactProvider implements FactProvider
     public function run(ProviderContext $context): array
     {
         $text = (string) $context->runtime->store->getFileFact($context->file->path, 'file.text');
-        $rulePortFacts = PhpRulePortFacts::summarize($text);
+        $testCallSummary = PhpFacts::testCallSummary($text, $context->file->path);
+        $rulePortFacts = PhpRulePortFacts::summarize($text, $testCallSummary['looksLikeTest']);
 
         return [
             'file.comments' => PhpFacts::comments($text),
@@ -43,7 +44,7 @@ final class PhpStructureFactProvider implements FactProvider
             'file.parserSummary' => PhpFacts::parserSummary($context->file->absolutePath),
             'file.phpDocTypeSummaries' => PhpFacts::phpDocTypeSummaries($context->file->absolutePath),
             'file.debugCalls' => PhpFacts::debugCalls($text),
-            'file.testCallSummary' => PhpFacts::testCallSummary($text, $context->file->path),
+            'file.testCallSummary' => $testCallSummary,
             'file.typeEscapeSummary' => PhpFacts::typeEscapeSummary($text),
             'file.statusEnvelopes' => $rulePortFacts['statusEnvelopes'],
             'file.genericArrayCasts' => $rulePortFacts['genericArrayCasts'],

--- a/src/Rule/DuplicateMockSetupRule.php
+++ b/src/Rule/DuplicateMockSetupRule.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SlopScan\Rule;
+
+use SlopScan\Model\Finding;
+use SlopScan\Runtime\ProviderContext;
+
+final class DuplicateMockSetupRule extends BaseRule
+{
+    public function id(): string { return 'php.duplicate-mock-setup'; }
+    public function family(): string { return 'tests'; }
+    public function scope(): string { return 'repo'; }
+    public function requires(): array { return ['repo.duplicateMockSetups']; }
+
+    public function evaluate(ProviderContext $context): array
+    {
+        $clusters = $context->runtime->store->getRepoFact('repo.duplicateMockSetups') ?? [];
+        if (!is_array($clusters)) {
+            return [];
+        }
+
+        /** @var array<string,list<array{label:string,fileCount:int,occurrences:list<array{path:string,line:int}>}>> $byPath */
+        $byPath = [];
+        foreach ($clusters as $cluster) {
+            if (!is_array($cluster)
+                || !is_string($cluster['label'] ?? null)
+                || !is_int($cluster['fileCount'] ?? null)
+                || !is_array($cluster['occurrences'] ?? null)
+            ) {
+                continue;
+            }
+
+            $paths = [];
+            $occurrences = [];
+            foreach ($cluster['occurrences'] as $occurrence) {
+                if (!is_array($occurrence) || !is_string($occurrence['path'] ?? null) || !is_int($occurrence['line'] ?? null)) {
+                    continue;
+                }
+                $paths[$occurrence['path']] = true;
+                $occurrences[] = ['path' => $occurrence['path'], 'line' => $occurrence['line']];
+            }
+
+            foreach (array_keys($paths) as $path) {
+                $byPath[$path][] = [
+                    'label' => $cluster['label'],
+                    'fileCount' => $cluster['fileCount'],
+                    'occurrences' => $occurrences,
+                ];
+            }
+        }
+        ksort($byPath, SORT_STRING);
+
+        $findings = [];
+        foreach ($byPath as $path => $pathClusters) {
+            $evidence = [];
+            $locations = [];
+            $score = 0.0;
+            foreach ($pathClusters as $cluster) {
+                $evidence[] = 'setup=' . $cluster['label'] . '|files=' . $cluster['fileCount'];
+                $score += 1.0 + max(0, $cluster['fileCount'] - 2) * 0.5;
+                foreach ($cluster['occurrences'] as $occurrence) {
+                    $locations[$occurrence['path'] . ':' . $occurrence['line']] = [
+                        'path' => $occurrence['path'],
+                        'line' => $occurrence['line'],
+                        'column' => 1,
+                    ];
+                }
+            }
+
+            sort($evidence, SORT_STRING);
+            ksort($locations, SORT_STRING);
+            $findings[] = new Finding(
+                $this->id(),
+                $this->family(),
+                $this->severity(),
+                'file',
+                'Found duplicated PHPUnit mock/setup pattern' . (count($pathClusters) === 1 ? '' : 's'),
+                $evidence,
+                min(5.0, $score),
+                array_values($locations),
+                $path,
+            );
+        }
+
+        return $findings;
+    }
+}

--- a/src/Rule/MisleadingPhpDocTypesRule.php
+++ b/src/Rule/MisleadingPhpDocTypesRule.php
@@ -13,14 +13,20 @@ final class MisleadingPhpDocTypesRule extends BaseRule
     public function family(): string { return 'documentation'; }
     public function severity(): string { return 'weak'; }
     public function scope(): string { return 'file'; }
-    public function requires(): array { return ['file.phpDocTypeSummaries']; }
+    public function requires(): array { return ['file.phpDocTypeSummaries', 'file.text']; }
 
     public function evaluate(ProviderContext $context): array
     {
         $findings = [];
+        $text = $context->runtime->store->getFileFact($context->file->path, 'file.text');
+        $localTypeAliases = is_string($text) ? self::localTypeAliases($text) : [];
 
         foreach ($context->runtime->store->getFileFact($context->file->path, 'file.phpDocTypeSummaries') ?? [] as $entry) {
             foreach ($entry['annotations'] as $annotation) {
+                if (self::usesLocalTypeAlias($annotation['phpDocRaw'], $localTypeAliases)) {
+                    continue;
+                }
+
                 $issue = self::issueForTypes(
                     $annotation['nativeType'],
                     $annotation['phpDocResolvedType'] ?? $annotation['phpDocType'],
@@ -59,6 +65,45 @@ final class MisleadingPhpDocTypesRule extends BaseRule
         }
 
         return $findings;
+    }
+
+    /** @return array<string,true> */
+    private static function localTypeAliases(string $text): array
+    {
+        if (preg_match_all(
+            '/@(?:phpstan|psalm)-(?:type|import-type)\s+([A-Za-z_][A-Za-z0-9_]*)\b/',
+            $text,
+            $matches,
+        ) !== false && isset($matches[1])) {
+            return array_fill_keys($matches[1], true);
+        }
+
+        return [];
+    }
+
+    /** @param array<string,true> $localTypeAliases */
+    private static function usesLocalTypeAlias(?string $phpDocRaw, array $localTypeAliases): bool
+    {
+        if ($phpDocRaw === null || $localTypeAliases === []) {
+            return false;
+        }
+
+        $parts = preg_split('/\s+/', trim($phpDocRaw), 2);
+        $typeExpression = $parts[0] ?? '';
+        if ($typeExpression === '') {
+            return false;
+        }
+
+        foreach (array_keys($localTypeAliases) as $alias) {
+            if (preg_match(
+                '/(?:^|[|&?(<,])\\\\?' . preg_quote($alias, '/') . '(?:$|[|&?)>\[\],])/',
+                $typeExpression,
+            ) === 1) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /** @return null|array{kind:string,reason:string} */

--- a/src/Rule/MisleadingPhpDocTypesRule.php
+++ b/src/Rule/MisleadingPhpDocTypesRule.php
@@ -70,15 +70,16 @@ final class MisleadingPhpDocTypesRule extends BaseRule
     /** @return array<string,true> */
     private static function localTypeAliases(string $text): array
     {
-        if (preg_match_all(
+        $count = preg_match_all(
             '/@(?:phpstan|psalm)-(?:type|import-type)\s+([A-Za-z_][A-Za-z0-9_]*)\b/',
             $text,
             $matches,
-        ) !== false && isset($matches[1])) {
-            return array_fill_keys($matches[1], true);
+        );
+        if ($count === false || $count === 0) {
+            return [];
         }
 
-        return [];
+        return array_fill_keys($matches[1], true);
     }
 
     /** @param array<string,true> $localTypeAliases */

--- a/src/Support/ScanCache.php
+++ b/src/Support/ScanCache.php
@@ -8,7 +8,7 @@ final class ScanCache
 {
     private const FORMAT_VERSION = 1;
     private const PROVIDER_SCHEMA_VERSIONS = [
-        'php.structure' => 5,
+        'php.structure' => 6,
     ];
 
     /** @var array<string,array<string,array{fingerprint:string,facts:array<string,mixed>}>> */

--- a/tests/DuplicateMockSetupRuleTest.php
+++ b/tests/DuplicateMockSetupRuleTest.php
@@ -83,6 +83,55 @@ PHP,
         }
     }
 
+    public function testFlagsEquivalentGetMockBuilderChainsAcrossThreeTestFiles(): void
+    {
+        $result = $this->analyzeFiles([
+            'tests/AlphaTest.php' => <<<'PHP'
+<?php
+use PHPUnit\Framework\TestCase;
+final class AlphaTest extends TestCase
+{
+    public function testAlpha(): void
+    {
+        $alpha = $this->getMockBuilder(AlphaGateway::class)->disableOriginalConstructor()->getMock();
+        self::assertInstanceOf(AlphaGateway::class, $alpha);
+    }
+}
+PHP,
+            'tests/BetaTest.php' => <<<'PHP'
+<?php
+use PHPUnit\Framework\TestCase;
+final class BetaTest extends TestCase
+{
+    public function testBeta(): void
+    {
+        $beta = $this->getMockBuilder(BetaGateway::class)->disableOriginalConstructor()->getMock();
+        self::assertInstanceOf(BetaGateway::class, $beta);
+    }
+}
+PHP,
+            'tests/GammaTest.php' => <<<'PHP'
+<?php
+use PHPUnit\Framework\TestCase;
+final class GammaTest extends TestCase
+{
+    public function testGamma(): void
+    {
+        $gamma = $this->getMockBuilder(GammaGateway::class)->disableOriginalConstructor()->getMock();
+        self::assertInstanceOf(GammaGateway::class, $gamma);
+    }
+}
+PHP,
+        ]);
+
+        $findings = $this->forRule($result->findings, 'php.duplicate-mock-setup');
+        self::assertCount(3, $findings);
+        foreach ($findings as $finding) {
+            self::assertSame(['setup=getMockBuilder|getMock|files=3'], $finding->evidence);
+            self::assertCount(3, $finding->locations);
+        }
+    }
+
     public function testNeedsThreeConfiguredFilesAndIgnoresBareMockDeclarations(): void
     {
         $result = $this->analyzeFiles([
@@ -130,6 +179,42 @@ final class BareMockTest extends TestCase
         $clock = $this->createMock(Clock::class);
 
         self::assertInstanceOf(Clock::class, $clock);
+    }
+}
+PHP,
+        ]);
+
+        self::assertSame([], $this->forRule($result->findings, 'php.duplicate-mock-setup'));
+    }
+
+    public function testRepeatedSetupInOneFileDoesNotSatisfyThreeFileThreshold(): void
+    {
+        $result = $this->analyzeFiles([
+            'tests/FirstServiceTest.php' => <<<'PHP'
+<?php
+use PHPUnit\Framework\TestCase;
+final class FirstServiceTest extends TestCase
+{
+    public function testFirst(): void
+    {
+        $first = $this->createMock(Clock::class);
+        $first->method('now')->willReturn(1);
+        $second = $this->createMock(Clock::class);
+        $second->method('later')->willReturn(2);
+        self::assertTrue(true);
+    }
+}
+PHP,
+            'tests/SecondServiceTest.php' => <<<'PHP'
+<?php
+use PHPUnit\Framework\TestCase;
+final class SecondServiceTest extends TestCase
+{
+    public function testSecond(): void
+    {
+        $clock = $this->createMock(Clock::class);
+        $clock->method('now')->willReturn(3);
+        self::assertTrue(true);
     }
 }
 PHP,

--- a/tests/DuplicateMockSetupRuleTest.php
+++ b/tests/DuplicateMockSetupRuleTest.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SlopScan\Tests;
+
+use PHPUnit\Framework\TestCase;
+use SlopScan\Analyzer;
+use SlopScan\Config;
+use SlopScan\DefaultRegistry;
+use SlopScan\Model\AnalysisResult;
+use SlopScan\Model\Finding;
+
+final class DuplicateMockSetupRuleTest extends TestCase
+{
+    public function testFlagsSameMockSetupShapeAcrossThreeTestFiles(): void
+    {
+        $result = $this->analyzeFiles([
+            'tests/ClockServiceTest.php' => <<<'PHP'
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class ClockServiceTest extends TestCase
+{
+    public function testFormatsCurrentTime(): void
+    {
+        $clock = $this->createMock(Clock::class);
+        $clock->method('now')->willReturn(1710000000);
+
+        self::assertSame('12:00', format_time($clock));
+    }
+}
+PHP,
+            'tests/OrderServiceTest.php' => <<<'PHP'
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class OrderServiceTest extends TestCase
+{
+    public function testUsesOrderTimestamp(): void
+    {
+        $timeSource = $this->createMock(TimeSource::class);
+        $timeSource->method('timestamp')->willReturn(1720000000);
+
+        self::assertSame(1720000000, order_timestamp($timeSource));
+    }
+}
+PHP,
+            'tests/TokenServiceTest.php' => <<<'PHP'
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class TokenServiceTest extends TestCase
+{
+    public function testUsesIssuedAt(): void
+    {
+        $provider = $this->createMock(DateProvider::class);
+        $provider->method('issuedAt')->willReturn(1730000000);
+
+        self::assertSame(1730000000, token_issued_at($provider));
+    }
+}
+PHP,
+        ]);
+
+        $findings = $this->forRule($result->findings, 'php.duplicate-mock-setup');
+        $paths = array_map(static fn (Finding $finding): ?string => $finding->path, $findings);
+        sort($paths, SORT_STRING);
+
+        self::assertSame(
+            [
+                'tests/ClockServiceTest.php',
+                'tests/OrderServiceTest.php',
+                'tests/TokenServiceTest.php',
+            ],
+            $paths,
+        );
+        foreach ($findings as $finding) {
+            self::assertCount(3, $finding->locations);
+        }
+    }
+
+    public function testNeedsThreeConfiguredFilesAndIgnoresBareMockDeclarations(): void
+    {
+        $result = $this->analyzeFiles([
+            'tests/FirstServiceTest.php' => <<<'PHP'
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class FirstServiceTest extends TestCase
+{
+    public function testFirst(): void
+    {
+        $clock = $this->createMock(Clock::class);
+        $clock->method('now')->willReturn(1);
+
+        self::assertSame(1, read_clock($clock));
+    }
+}
+PHP,
+            'tests/SecondServiceTest.php' => <<<'PHP'
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class SecondServiceTest extends TestCase
+{
+    public function testSecond(): void
+    {
+        $clock = $this->createMock(Clock::class);
+        $clock->method('now')->willReturn(2);
+
+        self::assertSame(2, read_clock($clock));
+    }
+}
+PHP,
+            'tests/BareMockTest.php' => <<<'PHP'
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class BareMockTest extends TestCase
+{
+    public function testBareMockIsNotSetupDuplication(): void
+    {
+        $clock = $this->createMock(Clock::class);
+
+        self::assertInstanceOf(Clock::class, $clock);
+    }
+}
+PHP,
+        ]);
+
+        self::assertSame([], $this->forRule($result->findings, 'php.duplicate-mock-setup'));
+    }
+
+    /**
+     * @param array<string, string> $files
+     */
+    private function analyzeFiles(array $files): AnalysisResult
+    {
+        $fixture = sys_get_temp_dir() . '/slop-scan-duplicate-mock-' . bin2hex(random_bytes(4));
+
+        foreach ($files as $path => $contents) {
+            $absolutePath = $fixture . '/' . $path;
+            $directory = dirname($absolutePath);
+            if (!is_dir($directory)) {
+                mkdir($directory, 0777, true);
+            }
+            file_put_contents($absolutePath, $contents);
+        }
+
+        try {
+            return (new Analyzer())->analyze(
+                $fixture,
+                Config::defaults(),
+                DefaultRegistry::create(),
+            );
+        } finally {
+            $this->remove($fixture);
+        }
+    }
+
+    /**
+     * @param list<Finding> $findings
+     * @return list<Finding>
+     */
+    private function forRule(array $findings, string $ruleId): array
+    {
+        return array_values(array_filter(
+            $findings,
+            static fn (Finding $finding): bool => $finding->ruleId === $ruleId,
+        ));
+    }
+
+    private function remove(string $path): void
+    {
+        if (!file_exists($path)) {
+            return;
+        }
+        if (is_file($path)) {
+            unlink($path);
+            return;
+        }
+
+        foreach (scandir($path) ?: [] as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $this->remove($path . DIRECTORY_SEPARATOR . $item);
+        }
+
+        rmdir($path);
+    }
+}

--- a/tests/ReviewRegressionTest.php
+++ b/tests/ReviewRegressionTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SlopScan\Tests;
+
+use PHPUnit\Framework\TestCase;
+use SlopScan\Analyzer;
+use SlopScan\Config;
+use SlopScan\DefaultRegistry;
+use SlopScan\Model\AnalysisResult;
+use SlopScan\Model\Finding;
+
+final class ReviewRegressionTest extends TestCase
+{
+    public function testDuplicateMockSetupIgnoresUnrelatedFluentApisAcrossThreeTestFiles(): void
+    {
+        $result = $this->analyzeFiles([
+            'tests/AlphaTest.php' => <<<'PHP'
+<?php
+use PHPUnit\Framework\TestCase;
+final class AlphaTest extends TestCase
+{
+    public function testAlpha(): void
+    {
+        $query = new QueryBuilder();
+        $query->method('active')->willReturn('id');
+        self::assertTrue(true);
+    }
+}
+PHP,
+            'tests/BetaTest.php' => <<<'PHP'
+<?php
+use PHPUnit\Framework\TestCase;
+final class BetaTest extends TestCase
+{
+    public function testBeta(): void
+    {
+        $query = new QueryBuilder();
+        $query->method('published')->willReturn('slug');
+        self::assertTrue(true);
+    }
+}
+PHP,
+            'tests/GammaTest.php' => <<<'PHP'
+<?php
+use PHPUnit\Framework\TestCase;
+final class GammaTest extends TestCase
+{
+    public function testGamma(): void
+    {
+        $query = new QueryBuilder();
+        $query->method('visible')->willReturn('name');
+        self::assertTrue(true);
+    }
+}
+PHP,
+        ]);
+
+        self::assertSame([], $this->forRule($result->findings, 'php.duplicate-mock-setup'));
+    }
+
+    public function testMisleadingPhpDocTypesAllowsLocalPhpstanTypeAlias(): void
+    {
+        $result = $this->analyzeFiles([
+            'src/AliasSummary.php' => <<<'PHP'
+<?php
+
+/**
+ * @phpstan-type Summary array{items:list<string>}
+ */
+final class AliasSummary
+{
+    /** @return Summary */
+    public static function summarize(): array
+    {
+        return ['items' => []];
+    }
+}
+PHP,
+        ]);
+
+        self::assertSame([], $this->forRule($result->findings, 'php.misleading-phpdoc-types'));
+    }
+
+    /** @param array<string,string> $files */
+    private function analyzeFiles(array $files): AnalysisResult
+    {
+        $fixture = sys_get_temp_dir() . '/slop-scan-review-regression-' . bin2hex(random_bytes(4));
+
+        foreach ($files as $path => $contents) {
+            $absolutePath = $fixture . '/' . $path;
+            $directory = dirname($absolutePath);
+            if (!is_dir($directory)) {
+                mkdir($directory, 0777, true);
+            }
+            file_put_contents($absolutePath, $contents);
+        }
+
+        try {
+            return (new Analyzer())->analyze($fixture, Config::defaults(), DefaultRegistry::create());
+        } finally {
+            $this->remove($fixture);
+        }
+    }
+
+    /**
+     * @param list<Finding> $findings
+     * @return list<Finding>
+     */
+    private function forRule(array $findings, string $ruleId): array
+    {
+        return array_values(array_filter(
+            $findings,
+            static fn (Finding $finding): bool => $finding->ruleId === $ruleId,
+        ));
+    }
+
+    private function remove(string $path): void
+    {
+        if (!file_exists($path)) {
+            return;
+        }
+        if (is_file($path)) {
+            unlink($path);
+            return;
+        }
+
+        foreach (scandir($path) ?: [] as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $this->remove($path . DIRECTORY_SEPARATOR . $item);
+        }
+
+        rmdir($path);
+    }
+}


### PR DESCRIPTION
Dogfood follow-up for SLOP-3.

Starts fixture-first with three realistic PHPUnit test files that repeat the same `createMock()` + `method()->willReturn()` structure while changing variable names, class names, method names and return values. That is deliberate: the signal is structural rather than a text clone.

The original SLOP-13 assumption that a brand-new repo fact provider was required did not survive implementation:

- `php.structure` already owns PHP AST-derived file facts;
- `repo.functionDuplication` already owns cross-file duplication aggregation;
- the red acceptance fixture was satisfied by extending those owners, with no new fact provider.

Parser ownership was tightened during the dogfood run as well. `voku/simple-php-code-parser:^0.22.3` is now the minimum dependency. `PhpRulePortFacts` uses `PhpCodeParser::getAstFromString()` instead of rebuilding `ParserFactory` + parent traversal locally.

The generic raw-AST mechanics motivated by this PR were moved upstream in `voku/Simple-PHP-Code-Parser#112` and released as `0.22.3`. This branch now consumes `AstNodeInspector::startColumn()` and `AstNodeInspector::shapeFingerprint()` directly; the local column and structural-fingerprint implementations have been deleted. The existing fingerprint depth remains explicitly pinned to 5 so rule behavior does not drift during the ownership move.

The same parser release also fixes PHP 8.5 lexical `self` / `parent` / `static` type preservation and a null-parent inheritdoc lookup. Those are correctness improvements for parser-derived facts but do not add new slop semantics here.

A broader attempt to replace `PhpFacts`' parser seam inside this PR was reverted after its cache/error tests proved that change is cross-cutting. The next reduction should parse each uncached PHP file once through the shared parser and feed that AST to the fact extractors, as a separate measured change rather than hiding parser-infrastructure surgery inside SLOP-3.

Remaining rule-specific predicates stay here. `NodeFinder` also stays direct rather than being hidden behind a home-grown query wrapper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection and reporting for repeated PHPUnit mock setups across three or more test files.
  * Findings include affected files and relevant evidence locations.
  * Recognizes equivalent mock-builder and return-value setup patterns.

* **Bug Fixes**
  * Improved handling of invalid or incomplete mock setup data.
  * Updated parsing support and refreshed cached analysis results.

* **Tests**
  * Added coverage for duplicate setups, thresholds, equivalent chains, bare mocks, and repeated setups within a single file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->