### PR TITLE
perf: parse PHP structure facts once per file

### DIFF
--- a/src/Fact/PhpFacts.php
+++ b/src/Fact/PhpFacts.php
@@ -12,6 +12,8 @@ use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\NodeFinder;
 use PhpParser\Node\Stmt;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\ParentConnectingVisitor;
 use PhpParser\Parser;
 use PhpParser\ParserFactory;
 use PhpParser\PrettyPrinter\Standard;
@@ -58,10 +60,10 @@ final class PhpFacts
         return $comments;
     }
 
-    /** @return list<array{name:string,signature:string,line:int,body:string,params:list<string>,passThroughCall:null|array{callee:string,args:list<string>},constantReturn:?string,magicNumbers:list<array{value:string,normalized:string,kind:string,line:int,column:int}>,classKind:?string,className:?string,namespaceName:?string}> */
-    public static function functions(string $text): array
+    /** @param null|list<Stmt> $statements @return list<array{name:string,signature:string,line:int,body:string,params:list<string>,passThroughCall:null|array{callee:string,args:list<string>},constantReturn:?string,magicNumbers:list<array{value:string,normalized:string,kind:string,line:int,column:int}>,classKind:?string,className:?string,namespaceName:?string}> */
+    public static function functions(string $text, ?array $statements = null): array
     {
-        $statements = self::parseStatements($text);
+        $statements ??= self::parseStatements($text);
         if ($statements === null) {
             return [];
         }
@@ -72,6 +74,7 @@ final class PhpFacts
     }
 
     /**
+     * @param null|list<Stmt> $statements
      * @return list<array{
      *     line:int,
      *     body:string,
@@ -84,9 +87,9 @@ final class PhpFacts
      *     thrownExceptions:list<array{class:?string,isGeneric:bool,preservesPrevious:bool,usesCaughtVariable:bool}>
      * }>
      */
-    public static function tryCatches(string $text): array
+    public static function tryCatches(string $text, ?array $statements = null): array
     {
-        $statements = self::parseStatements($text);
+        $statements ??= self::parseStatements($text);
         if ($statements === null) {
             return [];
         }
@@ -151,11 +154,12 @@ final class PhpFacts
     }
 
     /**
+     * @param null|list<Stmt> $statements
      * @return array{mixedTypeCount:int,castCount:int}
      */
-    public static function typeEscapeSummary(string $text): array
+    public static function typeEscapeSummary(string $text, ?array $statements = null): array
     {
-        $statements = self::parseStatements($text);
+        $statements ??= self::parseStatements($text);
         if ($statements === null) {
             return ['mixedTypeCount' => 0, 'castCount' => 0];
         }
@@ -182,10 +186,10 @@ final class PhpFacts
         return ['mixedTypeCount' => $mixedCount, 'castCount' => $castCount];
     }
 
-    /** @return list<array{name:string,line:int}> */
-    public static function debugCalls(string $text): array
+    /** @param null|list<Stmt> $statements @return list<array{name:string,line:int}> */
+    public static function debugCalls(string $text, ?array $statements = null): array
     {
-        $statements = self::parseStatements($text);
+        $statements ??= self::parseStatements($text);
         if ($statements === null) {
             return [];
         }
@@ -210,10 +214,10 @@ final class PhpFacts
         return $calls;
     }
 
-    /** @return array{looksLikeTest:bool,testCount:int,mockCount:int,assertionCount:int,expectationCount:int} */
-    public static function testCallSummary(string $text, string $path): array
+    /** @param null|list<Stmt> $statements @return array{looksLikeTest:bool,testCount:int,mockCount:int,assertionCount:int,expectationCount:int} */
+    public static function testCallSummary(string $text, string $path, ?array $statements = null): array
     {
-        $statements = self::parseStatements($text);
+        $statements ??= self::parseStatements($text);
         if ($statements === null) {
             return [
                 'looksLikeTest' => false,
@@ -262,6 +266,39 @@ final class PhpFacts
         self::$parserFactory = $parserFactory;
     }
 
+    /** @return array{statements:null|list<Stmt>,error:?string} */
+    public static function parseSyntax(string $text): array
+    {
+        try {
+            if (self::$parserFactory !== null) {
+                $statements = self::parser()->parse($text) ?? [];
+                $statements = (new NodeTraverser(new ParentConnectingVisitor()))->traverse($statements);
+                /** @var list<Stmt> $statements */
+            } else {
+                $statements = PhpCodeParser::getAstFromString($text);
+                /** @var list<Stmt> $statements */
+            }
+
+            return ['statements' => $statements, 'error' => null];
+        } catch (\Throwable $exception) {
+            return ['statements' => null, 'error' => $exception->getMessage()];
+        }
+    }
+
+    /** @param list<Stmt> $statements @return array{available:bool,classCount:int,functionCount:int} */
+    public static function parserSummaryFromStatements(array $statements): array
+    {
+        $finder = self::nodeFinder();
+        $classCount = count($finder->find($statements, static fn(Node $node): bool => $node instanceof Stmt\Class_ || $node instanceof Stmt\Interface_ || $node instanceof Stmt\Trait_ || $node instanceof Stmt\Enum_));
+        $functionCount = count($finder->findInstanceOf($statements, Stmt\Function_::class));
+
+        return [
+            'available' => true,
+            'classCount' => $classCount,
+            'functionCount' => $functionCount,
+        ];
+    }
+
     /** @return array{available:bool,classCount:int,functionCount:int,error?:string} */
     public static function parserSummary(string $absolutePath): array
     {
@@ -274,20 +311,17 @@ final class PhpFacts
             return ['available' => true, 'classCount' => 0, 'functionCount' => 0, 'error' => 'Unable to read file'];
         }
 
-        try {
-            $statements = self::parser()->parse($text) ?? [];
-            $finder = self::nodeFinder();
-            $classCount = count($finder->find($statements, static fn(Node $node): bool => $node instanceof Stmt\Class_ || $node instanceof Stmt\Interface_ || $node instanceof Stmt\Trait_ || $node instanceof Stmt\Enum_));
-            $functionCount = count($finder->findInstanceOf($statements, Stmt\Function_::class));
-
+        $syntax = self::parseSyntax($text);
+        if ($syntax['statements'] === null) {
             return [
                 'available' => true,
-                'classCount' => $classCount,
-                'functionCount' => $functionCount,
+                'classCount' => 0,
+                'functionCount' => 0,
+                'error' => $syntax['error'] ?? 'Unable to parse PHP source',
             ];
-        } catch (\Throwable $exception) {
-            return ['available' => true, 'classCount' => 0, 'functionCount' => 0, 'error' => $exception->getMessage()];
         }
+
+        return self::parserSummaryFromStatements($syntax['statements']);
     }
 
     /** @param list<Stmt> $statements */
@@ -357,14 +391,10 @@ final class PhpFacts
         ];
     }
 
-    /** @return list<Stmt> */
+    /** @return null|list<Stmt> */
     private static function parseStatements(string $text): ?array
     {
-        try {
-            return self::parser()->parse($text) ?? [];
-        } catch (\Throwable) {
-            return null;
-        }
+        return self::parseSyntax($text)['statements'];
     }
 
     private static function parser(): Parser

--- a/src/Fact/PhpFacts.php
+++ b/src/Fact/PhpFacts.php
@@ -13,6 +13,7 @@ use PhpParser\Node\Name;
 use PhpParser\NodeFinder;
 use PhpParser\Node\Stmt;
 use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NameResolver;
 use PhpParser\NodeVisitor\ParentConnectingVisitor;
 use PhpParser\Parser;
 use PhpParser\ParserFactory;
@@ -270,14 +271,12 @@ final class PhpFacts
     public static function parseSyntax(string $text): array
     {
         try {
-            if (self::$parserFactory !== null) {
-                $statements = self::parser()->parse($text) ?? [];
-                $statements = (new NodeTraverser(new ParentConnectingVisitor()))->traverse($statements);
-                /** @var list<Stmt> $statements */
-            } else {
-                $statements = PhpCodeParser::getAstFromString($text);
-                /** @var list<Stmt> $statements */
-            }
+            $statements = self::parser()->parse($text) ?? [];
+            $statements = (new NodeTraverser(
+                new ParentConnectingVisitor(),
+                new NameResolver(null, ['replaceNodes' => false]),
+            ))->traverse($statements);
+            /** @var list<Stmt> $statements */
 
             return ['statements' => $statements, 'error' => null];
         } catch (\Throwable $exception) {

--- a/src/Fact/PhpRulePortFacts.php
+++ b/src/Fact/PhpRulePortFacts.php
@@ -67,10 +67,10 @@ final class PhpRulePortFacts
         'rows',
     ];
 
-    /** @return Summary */
-    public static function summarize(string $text, bool $includeTestMockSetups = false): array
+    /** @param null|list<Stmt> $statements @return Summary */
+    public static function summarize(string $text, bool $includeTestMockSetups = false, ?array $statements = null): array
     {
-        $statements = self::parseStatementsWithParents($text);
+        $statements ??= self::parseStatementsWithParents($text);
         if ($statements === null) {
             return [
                 'genericArrayCasts' => [],

--- a/src/Fact/PhpRulePortFacts.php
+++ b/src/Fact/PhpRulePortFacts.php
@@ -171,7 +171,7 @@ final class PhpRulePortFacts
 
         if (!$expr instanceof Expr\FuncCall
             || !$expr->name instanceof Name
-            || strtolower(ltrim($expr->name->toString(), '\\')) !== 'json_decode'
+            || strtolower(ltrim(self::resolvedName($expr->name), '\\')) !== 'json_decode'
         ) {
             return null;
         }
@@ -270,12 +270,19 @@ final class PhpRulePortFacts
 
         if ($call instanceof Expr\New_
             && $call->class instanceof Name
-            && str_ends_with(strtolower($call->class->toString()), 'jsonresponse')
+            && str_ends_with(strtolower(self::resolvedName($call->class)), 'jsonresponse')
         ) {
             return 'json-generic-status-envelope';
         }
 
         return 'assigned-generic-status-envelope';
+    }
+
+    private static function resolvedName(Name $name): string
+    {
+        $resolved = $name->getAttribute('resolvedName');
+
+        return $resolved instanceof Name ? $resolved->toString() : $name->toString();
     }
 
     /** @param list<Stmt> $statements @return list<TestMockSetup> */

--- a/src/Fact/PhpStructureFactProvider.php
+++ b/src/Fact/PhpStructureFactProvider.php
@@ -34,18 +34,28 @@ final class PhpStructureFactProvider implements FactProvider
     public function run(ProviderContext $context): array
     {
         $text = (string) $context->runtime->store->getFileFact($context->file->path, 'file.text');
-        $testCallSummary = PhpFacts::testCallSummary($text, $context->file->path);
-        $rulePortFacts = PhpRulePortFacts::summarize($text, $testCallSummary['looksLikeTest']);
+        $syntax = PhpFacts::parseSyntax($text);
+        $statements = $syntax['statements'] ?? [];
+        $testCallSummary = PhpFacts::testCallSummary($text, $context->file->path, $statements);
+        $rulePortFacts = PhpRulePortFacts::summarize($text, $testCallSummary['looksLikeTest'], $statements);
+        $parserSummary = $syntax['statements'] === null
+            ? [
+                'available' => true,
+                'classCount' => 0,
+                'functionCount' => 0,
+                'error' => $syntax['error'] ?? 'Unable to parse PHP source',
+            ]
+            : PhpFacts::parserSummaryFromStatements($statements);
 
         return [
             'file.comments' => PhpFacts::comments($text),
-            'file.functionSummaries' => PhpFacts::functions($text),
-            'file.tryCatches' => PhpFacts::tryCatches($text),
-            'file.parserSummary' => PhpFacts::parserSummary($context->file->absolutePath),
+            'file.functionSummaries' => PhpFacts::functions($text, $statements),
+            'file.tryCatches' => PhpFacts::tryCatches($text, $statements),
+            'file.parserSummary' => $parserSummary,
             'file.phpDocTypeSummaries' => PhpFacts::phpDocTypeSummaries($context->file->absolutePath),
-            'file.debugCalls' => PhpFacts::debugCalls($text),
+            'file.debugCalls' => PhpFacts::debugCalls($text, $statements),
             'file.testCallSummary' => $testCallSummary,
-            'file.typeEscapeSummary' => PhpFacts::typeEscapeSummary($text),
+            'file.typeEscapeSummary' => PhpFacts::typeEscapeSummary($text, $statements),
             'file.statusEnvelopes' => $rulePortFacts['statusEnvelopes'],
             'file.genericArrayCasts' => $rulePortFacts['genericArrayCasts'],
             'file.caughtExceptionNormalizations' => $rulePortFacts['caughtExceptionNormalizations'],

--- a/tests/PhpStructureParseOnceTest.php
+++ b/tests/PhpStructureParseOnceTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SlopScan\Tests;
+
+use PhpParser\Parser;
+use PhpParser\ParserFactory;
+use PHPUnit\Framework\TestCase;
+use SlopScan\Analyzer;
+use SlopScan\Config;
+use SlopScan\DefaultRegistry;
+use SlopScan\Fact\PhpFacts;
+
+final class PhpStructureParseOnceTest extends TestCase
+{
+    public function testUncachedPhpStructureFactsShareOneRawAstParse(): void
+    {
+        $fixture = sys_get_temp_dir() . '/slop-scan-parse-once-' . bin2hex(random_bytes(4));
+        mkdir($fixture . '/src', 0777, true);
+        file_put_contents($fixture . '/src/Example.php', <<<'PHP'
+<?php
+
+final class Example
+{
+    public function run(string $value): string
+    {
+        try {
+            var_dump($value);
+            return transform($value);
+        } catch (Throwable $exception) {
+            return $exception->getMessage();
+        }
+    }
+}
+PHP);
+
+        $parserCalls = 0;
+        PhpFacts::useParserFactoryForTesting(static function () use (&$parserCalls): Parser {
+            $parserCalls++;
+
+            return (new ParserFactory())->createForHostVersion();
+        });
+
+        try {
+            (new Analyzer())->analyze($fixture, Config::defaults(), DefaultRegistry::create());
+
+            self::assertSame(1, $parserCalls, 'php.structure should parse one uncached PHP source once for raw AST-derived facts.');
+        } finally {
+            PhpFacts::useParserFactoryForTesting(null);
+            $this->remove($fixture);
+        }
+    }
+
+    private function remove(string $path): void
+    {
+        if (!file_exists($path)) {
+            return;
+        }
+        if (is_file($path)) {
+            unlink($path);
+            return;
+        }
+
+        foreach (scandir($path) ?: [] as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $this->remove($path . DIRECTORY_SEPARATOR . $item);
+        }
+
+        rmdir($path);
+    }
+}

--- a/tests/PhpStructureParseOnceTest.php
+++ b/tests/PhpStructureParseOnceTest.php
@@ -11,6 +11,7 @@ use SlopScan\Analyzer;
 use SlopScan\Config;
 use SlopScan\DefaultRegistry;
 use SlopScan\Fact\PhpFacts;
+use SlopScan\Fact\PhpRulePortFacts;
 
 final class PhpStructureParseOnceTest extends TestCase
 {
@@ -50,6 +51,38 @@ PHP);
             PhpFacts::useParserFactoryForTesting(null);
             $this->remove($fixture);
         }
+    }
+
+    public function testSharedSyntaxKeepsResolvedAliasesForRulePortFacts(): void
+    {
+        $text = <<<'PHP'
+<?php
+
+namespace App;
+
+use Symfony\Component\HttpFoundation\JsonResponse as ApiResponse;
+use function json_decode as decode_json;
+
+function decode(string $raw): array
+{
+    $data = decode_json($raw, true);
+
+    return $data;
+}
+
+function response(array $rows): object
+{
+    return new ApiResponse(['ok' => true, 'data' => $rows]);
+}
+PHP;
+
+        $syntax = PhpFacts::parseSyntax($text);
+        self::assertNotNull($syntax['statements']);
+
+        $summary = PhpRulePortFacts::summarize($text, false, $syntax['statements']);
+
+        self::assertSame('json-decode-assoc', $summary['genericArrayCasts'][0]['kind'] ?? null);
+        self::assertSame('json-generic-status-envelope', $summary['statusEnvelopes'][0]['kind'] ?? null);
     }
 
     private function remove(string $path): void


### PR DESCRIPTION
Reduction follow-up from merged #35.

## Goal

Parse each uncached PHP source exactly once for raw AST-derived `php.structure` facts, then reuse that syntax tree across the existing extractors. Keep the PHPDoc model extraction separate because `PhpCodeParser::getPhpFiles()` is a distinct semantic/model layer and there is no existing public model-from-AST seam worth inventing around in this PR.

## Red baseline

The first commit (`36bd76f`) was intentionally test-only. `PhpStructureParseOnceTest` injected the existing `PhpFacts` parser seam and asserted one parser invocation for one uncached PHP file.

CI run 107 failed exactly on that assertion:

- expected parser calls: `1`
- actual parser calls: `6`
- syntax: green
- PHPStan: green
- PHPUnit: red only on the new parse-count regression

## Narrow implementation

- `PhpFacts::parseSyntax()` owns one parse and adds parent links plus non-mutating name-resolution metadata.
- Existing raw AST extractors (`functions`, `tryCatches`, `debugCalls`, `testCallSummary`, `typeEscapeSummary`, parser summary) accept and reuse the same statements.
- `PhpStructureFactProvider` parses once and passes the shared statements to those extractors and to `PhpRulePortFacts`.
- `PhpRulePortFacts` reads `resolvedName` metadata only where static name identity matters (`json_decode` and `JsonResponse`).
- No static cross-file AST cache, new provider, lifecycle layer, query wrapper, or parser manager was added.

## Rejected intermediate

An intermediate implementation fed the names-replaced upstream AST directly to all `PhpFacts`. Full PHPUnit caught a semantic drift: pretty-printed function bodies changed `fallback($e)` to `\\fallback($e)`, which would also change `repo.cloneFunctionBodies` fingerprints. That approach was discarded rather than weakening the existing contract.

The final implementation uses php-parser name resolution with `replaceNodes=false`: raw syntax remains raw, while resolved identities are metadata on the same parsed tree.

## Regression coverage

The original parse-count test remains unchanged and now passes at `1` parser call.

A companion regression also proves that the one-tree approach preserves resolved-name behavior for:

- `use function json_decode as decode_json`
- `use Symfony\\Component\\HttpFoundation\\JsonResponse as ApiResponse`

So the reduction is not merely a parser-call counter trick.

## Final candidate

Head: `b73c6647efaf24594ee117db96a273796b4876d8`

CI run 113 is fully green:

- Composer validation: green
- PHP syntax: green
- PHPStan: no errors
- PHPUnit: **154 tests, 731 assertions**
- self-scan dogfood check: green
- PHAR build: green
- PHAR verification: green

Net contract: raw AST parser invocations for one uncached PHP file are reduced **6 → 1** while existing raw-body/clone semantics and resolved Rule-Port alias behavior remain covered.