### PR TITLE
chore: align dependency updates with PHP 8.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "infection/infection": "^0.34.2",
         "phpstan/phpstan": "^2.2.8",
         "phpunit/phpunit": "^12.5",
-        "voku/agent-loop": "^0.16.3"
+        "voku/agent-loop": "^0.16.5"
     },
     "license": "MIT",
     "authors": [

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "constraintsFiltering": "strict",
   "forkProcessing": "enabled"
 }


### PR DESCRIPTION
Follow-up cleanup after #35/#36 and the dependency audit.

## Why

Renovate opened PHPUnit 13 (#25) and Symfony Console 8 (#27), but both are incompatible with this repository's declared `php ^8.3` contract:

- PHPUnit 13 requires PHP >= 8.4.1.
- Symfony Console 8 requires PHP >= 8.4 (8.1 requires >= 8.4.1).

Those PRs fail during `composer install`, before syntax, PHPStan, tests, self-scan, or PHAR verification can run.

## Change

- enable Renovate `constraintsFiltering: strict` so Packagist releases are filtered against the PHP constraint already declared in `composer.json`;
- raise the explicit dev floor from `voku/agent-loop:^0.16.3` to `^0.16.5`, the current tagged line used by the workflow dogfood.

No package-specific ignore list and no duplicated PHP-version policy is introduced.